### PR TITLE
bug fix: remove components handling of <li> by react markdown

### DIFF
--- a/src/element/Text.tsx
+++ b/src/element/Text.tsx
@@ -142,11 +142,6 @@ function extractHashtags(fragments: Fragment[]) {
     }).flat();
 }
 
-function transformLi({ body, tags, users }: TextFragment) {
-    let fragments = transformText({ body, tags, users })
-    return <li>{fragments}</li>
-}
-
 function transformParagraph({ body, tags, users }: TextFragment) {
     const fragments = transformText({ body, tags, users })
     if (fragments.every(f => typeof f === 'string')) {
@@ -182,7 +177,6 @@ export default function Text({ content, tags, users }: TextProps) {
         return {
             p: (x: any) => transformParagraph({ body: x.children, tags, users }),
             a: (x: any) => transformHttpLink(x.href),
-            li: (x: any) => transformLi({ body: x.children, tags, users }),
         };
     }, [content]);
     return <ReactMarkdown className="text" components={components}>{content}</ReactMarkdown>


### PR DESCRIPTION
possible fix to: [#84](https://github.com/v0l/snort/issues/84#issue-1548221905)

react markdown seam to crash if \<li\> is also handled in components
