### PR TITLE
filter for self dms

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -10,7 +10,7 @@ import useEventPublisher from "../feed/EventPublisher";
 
 import DM from "../element/DM";
 import { RawEvent } from "../nostr";
-import { dmsInChat } from "./MessagesPage";
+import { dmsInChat, isToSelf } from "./MessagesPage";
 
 type RouterParams = {
     id: string
@@ -20,13 +20,14 @@ export default function ChatPage() {
     const params = useParams<RouterParams>();
     const publisher = useEventPublisher();
     const id = bech32ToHex(params.id ?? "");
+    const pubKey = useSelector<any>(s => s.login.publicKey);
     const dms = useSelector<any, RawEvent[]>(s => filterDms(s.login.dms));
     const [content, setContent] = useState<string>();
     const { ref, inView, entry } = useInView();
     const dmListRef = useRef<HTMLDivElement>(null);
 
     function filterDms(dms: RawEvent[]) {
-        return dmsInChat(dms, id);
+        return dmsInChat(id === pubKey ? dms.filter(d => isToSelf(d, pubKey)) : dms, id);
     }
 
     const sortedDms = useMemo<any[]>(() => {

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -73,6 +73,10 @@ function unreadDms(dms: RawEvent[], myPubKey: HexKey, pk: HexKey) {
 }
 
 function newestMessage(dms: RawEvent[], myPubKey: HexKey, pk: HexKey) {
+    if(pk === myPubKey) {
+        return dmsInChat(dms.filter(d => isToSelf(d, myPubKey)), pk).reduce((acc, v) => acc = v.created_at > acc ? v.created_at : acc, 0);
+    }
+
     return dmsInChat(dms, pk).reduce((acc, v) => acc = v.created_at > acc ? v.created_at : acc, 0);
 }
 


### PR DESCRIPTION
The DMs screen was showing an entry for your own DM, but it contained events from every DM that you've been involved in.

I filtered out the DMs that you sent to yourself for that message, almost like the "note to self" feature on Signal.