### PR TITLE
feat: soundcloud embed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Fast nostr web ui" />
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self'; child-src 'none'; worker-src 'self'; frame-src youtube.com www.youtube.com https://platform.twitter.com https://embed.tidal.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src wss://* 'self' https://*; img-src * data:; font-src https://fonts.gstatic.com; media-src *; script-src 'self' https://static.cloudflareinsights.com https://platform.twitter.com https://embed.tidal.com;" />
+    content="default-src 'self'; child-src 'none'; worker-src 'self'; frame-src youtube.com www.youtube.com https://platform.twitter.com https://embed.tidal.com https://www.mixcloud.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src wss://* 'self' https://*; img-src * data:; font-src https://fonts.gstatic.com; media-src *; script-src 'self' https://static.cloudflareinsights.com https://platform.twitter.com https://embed.tidal.com;" />
 
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/nostrich_512.png" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -89,3 +89,9 @@ export const HashtagRegex = /(#[^\s!@#$%^&*()=+.\/,\[{\]};:'"?><]+)/;
  * Tidal share link regex
  */
 export const TidalRegex = /tidal\.com\/(?:browse\/)?(\w+)\/([a-z0-9-]+)/i;
+
+/**
+ * SoundCloud regex
+ */
+
+export const SoundCloudRegex = /mixcloud\.com\/(?!live)([a-zA-Z0-9]+)\/([a-zA-Z0-9-]+)/

--- a/src/Element/SoundCloudEmded.tsx
+++ b/src/Element/SoundCloudEmded.tsx
@@ -1,0 +1,27 @@
+import { SoundCloudRegex } from "Const";
+import { useSelector } from "react-redux";
+import { RootState } from "State/Store";
+
+const SoundCloudEmbed =  ({link}:  {link: string}) => {
+
+    const feedPath = (SoundCloudRegex.test(link) && RegExp.$1) + "%2F" + ( SoundCloudRegex.test(link) && RegExp.$2)
+
+    const lightTheme = useSelector<RootState, boolean>(s => s.login.preferences.theme === "light");
+
+    const lightParams = lightTheme ? "light=1" : "light=0";
+
+    return(
+        <>
+        <br/>
+        <iframe
+            title="SoundCloud player"
+            width="100%"
+            height="120"
+            frameBorder="0"
+            src={`https://www.mixcloud.com/widget/iframe/?hide_cover=1&${lightParams}&feed=%2F${feedPath}%2F`}
+            />
+        </>
+    )
+}
+
+export default SoundCloudEmbed;

--- a/src/Element/Text.tsx
+++ b/src/Element/Text.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import { TwitterTweetEmbed } from "react-twitter-embed";
 
-import { UrlRegex, FileExtensionRegex, MentionRegex, InvoiceRegex, YoutubeUrlRegex, TweetUrlRegex, HashtagRegex, TidalRegex } from "Const";
+import { UrlRegex, FileExtensionRegex, MentionRegex, InvoiceRegex, YoutubeUrlRegex, TweetUrlRegex, HashtagRegex, TidalRegex, SoundCloudRegex } from "Const";
 import { eventLink, hexToBech32 } from "Util";
 import Invoice from "Element/Invoice";
 import Hashtag from "Element/Hashtag";
@@ -16,6 +16,7 @@ import TidalEmbed from "Element/TidalEmbed";
 import { useSelector } from 'react-redux';
 import { RootState } from 'State/Store';
 import { UserPreferences } from 'State/Login';
+import  SoundCloudEmbed from 'Element/SoundCloudEmded'
 
 function transformHttpLink(a: string, pref: UserPreferences) {
     try {
@@ -26,6 +27,7 @@ function transformHttpLink(a: string, pref: UserPreferences) {
         const youtubeId = YoutubeUrlRegex.test(a) && RegExp.$1;
         const tweetId = TweetUrlRegex.test(a) && RegExp.$2;
         const tidalId = TidalRegex.test(a) && RegExp.$1;
+        const soundcloundId = SoundCloudRegex.test(a) && RegExp.$1;
         const extension = FileExtensionRegex.test(url.pathname.toLowerCase()) && RegExp.$1;
         if (extension) {
             switch (extension) {
@@ -71,6 +73,8 @@ function transformHttpLink(a: string, pref: UserPreferences) {
             )
         } else if (tidalId) {
             return <TidalEmbed link={a} />
+        } else if (soundcloundId){
+            return <SoundCloudEmbed link={a} />
         } else {
             return <a href={a} onClick={(e) => e.stopPropagation()} target="_blank" rel="noreferrer" className="ext">{a}</a>
         }


### PR DESCRIPTION
WIP... it works with the mixcloud URLs, but not the soundcloud :) 

It should close https://github.com/v0l/snort/issues/98 

I'm not rendering anything if it's a live URL. Not sure how to inline that player. 

<img width="745" alt="Screenshot 2023-01-21 at 9 17 30 AM" src="https://user-images.githubusercontent.com/16559/213873565-65b27fb1-8655-4f40-ad7f-e8d3ed326842.png">

<img width="748" alt="Screenshot 2023-01-21 at 9 17 09 AM" src="https://user-images.githubusercontent.com/16559/213873566-76681f5e-5cb3-425c-848c-e940b9e25a93.png">
