### PR TITLE
Make Markdown more interoperable

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-textarea-autosize": "^8.4.0",
     "react-twitter-embed": "^4.0.4",
     "typescript": "^4.9.4",
+    "unist-util-visit": "^4.1.2",
     "uuid": "^9.0.0",
     "workbox-background-sync": "^6.4.2",
     "workbox-broadcast-update": "^6.4.2",

--- a/src/Element/Text.tsx
+++ b/src/Element/Text.tsx
@@ -229,7 +229,7 @@ export default function Text({ content, tags, users }: TextProps) {
                   node.type === 'definition')
             ) {
                   node.type = 'text';
-                  node.value = content.slice(node.position.start.offset, node.position.end.offset);
+                  node.value = content.slice(node.position.start.offset, node.position.end.offset).replace(/\)$/, ' )');
                   return SKIP;
             }
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6043,11 +6043,6 @@ js-sha3@0.8.0:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
 
-js-stylesheet@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/js-stylesheet/-/js-stylesheet-0.0.1.tgz#12cc1451220e454184b46de3b098c0d154762c38"
-  integrity sha512-jSPbDIaHlK8IFXEbE6MZkeAQshRHHxxOcQ+LCZejm3KpW+POpi2TE3GXWoFsOOG2+AhCTWHjD7AXRFt3FDm8Zw==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -7999,13 +7994,6 @@ react-markdown@^8.0.4:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
-react-menu@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/react-menu/-/react-menu-0.0.10.tgz#c2b338cdd88e4c436325969239089e0752a142bc"
-  integrity sha512-SGl/OZljPUB1ITWBG2wt1p7hyE3Y449O9FUezxkKzu+JM5HWkPjrU/JRmG4ZguyegLAnZx3qyjhdFYqB44sqJw==
-  dependencies:
-    js-stylesheet "0.0.1"
-
 react-query@^3.39.2:
   version "3.39.2"
   resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.2.tgz#9224140f0296f01e9664b78ed6e4f69a0cc9216f"
@@ -9349,6 +9337,15 @@ unist-util-visit@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.1.tgz#1c4842d70bd3df6cc545276f5164f933390a9aad"
   integrity sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.1.1"
+
+unist-util-visit@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.2.tgz#125a42d1eb876283715a3cb5cceaa531828c72e2"
+  integrity sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"


### PR DESCRIPTION
By disallowing the annoying link/image syntax that would cause terrible rendering bugs in other clients.

As result of this change, this note:

```
# titles still work

- lists
- still
- work

normal https://literal.links and `monospace` still work

**bold** and _italic_ still work

just [annoying](https://syntax-heavy.links/likethis) do not work, and ![the even](https://more.annoying/images.png)

normal images work fine: https://pixy.org/src/487/4870083.jpg
```

Renders like this: 
![2023-01-27-183610_699x896_scrot](https://user-images.githubusercontent.com/1653275/215205653-b346da44-8501-4b91-beed-dc41bd6ccc1e.png)
