### PR TITLE
Show absolute time on hover

### DIFF
--- a/src/Element/NoteTime.tsx
+++ b/src/Element/NoteTime.tsx
@@ -12,6 +12,8 @@ export interface NoteTimeProps {
 export default function NoteTime(props: NoteTimeProps) {
     const [time, setTime] = useState<string>();
     const { from, fallback } = props;
+    const absoluteTime = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'long'}).format(from);
+    const isoDate = new Date(from).toISOString();
 
     function calcTime() {
         let fromDate = new Date(from);
@@ -46,5 +48,5 @@ export default function NoteTime(props: NoteTimeProps) {
         return () => clearInterval(t);
     }, [from]);
 
-    return <>{time}</>
+    return <time dateTime={isoDate} title={absoluteTime}>{time}</time>
 }


### PR DESCRIPTION
This is a suggestion to fix issue https://github.com/v0l/snort/issues/46

The NoteTime now renders as a `<time>` element and will show the absolute time on hover using the title attribute (similar to how GitHub does it).

I have also added a `datetime` attribute.