### PR TITLE
Use the current embed player via TIDALs OEmbed API.

### DIFF
--- a/src/Element/TidalEmbed.tsx
+++ b/src/Element/TidalEmbed.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { CSSProperties, useEffect, useState } from "react";
 import { TidalRegex } from "Const";
 
 // Re-use dom parser across instances of TidalEmbed
@@ -34,6 +34,7 @@ async function oembedLookup (link: string) {
 const TidalEmbed = ({ link }: { link: string }) => {
     const [source, setSource] = useState<string>();
     const [height, setHeight] = useState<number>();
+    const extraStyles = link.includes('video') ? { aspectRatio: "16 / 9"  } : { height };
 
     useEffect(() => {
         oembedLookup(link).then(data => {
@@ -43,7 +44,7 @@ const TidalEmbed = ({ link }: { link: string }) => {
     }, [link]);
 
     if (!source) return <a href={link} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()} className="ext">{link}</a>;
-    return <iframe src={source} height={height} width="100%" title="TIDAL Embed" frameBorder={0} />;
+    return <iframe src={source} style={extraStyles} width="100%" title="TIDAL Embed" frameBorder={0} />;
 }
 
 export default TidalEmbed;

--- a/src/Element/TidalEmbed.tsx
+++ b/src/Element/TidalEmbed.tsx
@@ -1,27 +1,32 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useState } from "react";
 import { TidalRegex } from "Const";
 
+async function oembedLookup (link: string) {
+    // Regex + re-construct to handle both tidal.com/type/id and tidal.com/browse/type/id links.
+    const regexResult = TidalRegex.exec(link);
+
+    if (!regexResult) {
+        return undefined;
+    }
+
+    const [, productType, productId] = regexResult;
+    const oembedApi = `https://oembed.stage.tidal.com/?url=https://tidal.com/browse/${productType}/${productId}`;
+
+    const apiResponse = await fetch(oembedApi);
+    const json = await apiResponse.json();
+
+    return json.html;
+}
+
 const TidalEmbed = ({ link }: { link: string }) => {
-    const data = useMemo(() => {
-        const match = link.match(TidalRegex);
-        if (match?.length != 3) {
-            return null;
-        }
-        let type = match[1][0];
-        let id = match[2];
-        return { type, id };
+    const [embed, setEmbed] = useState();
+
+    useEffect(() => {
+        oembedLookup(link).then(setEmbed);
     }, [link]);
 
-    const ScriptSrc = "https://embed.tidal.com/tidal-embed.js";
-    useEffect(() => {
-        let sTag = document.createElement("script");
-        sTag.src = ScriptSrc;
-        sTag.async = true;
-        document.head.appendChild(sTag);
-    }, []);
-
-    if (!data) return <a href={link} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()} className="ext">{link}</a>;
-    return <div className="tidal-embed" data-type={data.type} data-id={data.id}></div>;
+    if (!embed) return <a href={link} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()} className="ext">{link}</a>;
+    return <div dangerouslySetInnerHTML={{__html: embed}}></div>;
 }
 
 export default TidalEmbed;


### PR DESCRIPTION
The code was using the old unmaintained embed player. This updates the code to use the newest one via our OEmbed API: https://oembed.tidal.com/?url=https://tidal.com/browse/track/145596276

The OEmbed API delivers the embed with sizes for different embed types. `dangerouslySetInnerHTML` is a bit sad, if wanted I can refactor to instead read out sizes from the delivered iframe and set those on a new <iframe> in the component.

https://user-images.githubusercontent.com/877455/216334497-f429daa3-4cf2-4dcd-8114-a0cabfa0fec3.mov

