### PR TITLE
Revert cc18567 and partially revert 40a5e00

### DIFF
--- a/src/Element/Avatar.css
+++ b/src/Element/Avatar.css
@@ -14,6 +14,12 @@
     background-image: var(--img-url), var(--snort-gradient);
 }
 
+.avatar[data-domain="nostrplebs.com"], .avatar[data-domain="nostriches.net"],
+.avatar[data-domain="nostrpurple.com"], .avatar[data-domain="nostr.fan"],
+.avatar[data-domain="nostrich.zone"] {
+    background-image: var(--img-url), var(--nostrplebs-gradient);
+}
+
 .avatar[data-domain="strike.army"] { 
     background-image: var(--img-url), var(--strike-army-gradient);
 }

--- a/src/Element/Nip05.css
+++ b/src/Element/Nip05.css
@@ -26,24 +26,10 @@
   background-image: var(--strike-army-gradient);
 }
 
+.nip05 .domain[data-domain="nostriches.net"], .nip05 .domain[data-domain="nostrich.zone"],
+.nip05 .domain[data-domain="nostrpurple.com"], .nip05 .domain[data-domain="nostr.fan"],
 .nip05 .domain[data-domain="nostrplebs.com"] {
-  color: var(--highlight);
-  background-color: var(--highlight);
-}
-
-.nip05 .domain[data-domain="nostrpurple.com"] {
-  color: var(--highlight);
-  background-color: var(--highlight);
-}
-
-.nip05 .domain[data-domain="nostr.fan"] {
-  color: var(--highlight);
-  background-color: var(--highlight);
-}
-
-.nip05 .domain[data-domain="nostriches.net"] {
-  color: var(--highlight);
-  background-color: var(--highlight);
+  background-image: var(--nostrplebs-gradient);
 }
 
 .nip05 .badge {

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,7 @@
   --paid-invoice-gradient: linear-gradient(45deg, var(--note-bg) 50%, rgba(161, 120, 255, .6), rgba(255, 107, 175, .6) 108.33%);
   --expired-invoice-gradient: linear-gradient(45deg, var(--note-bg) 50%, var(--gray), var(--gray-superdark));
   --strike-army-gradient: linear-gradient(to bottom right, #CCFF00, #a1c900);
+  --nostrplebs-gradient: linear-gradient(to bottom right, #ff3cac, #2b86c5);
 }
 
 html.light {


### PR DESCRIPTION
While I do get the goal with making Snort IDs more distinct (increasing purchases), this is most likely not going to work since people usually do not consider solely the color of the ID as a factor in buying an ID.