### PR TITLE
fix Content Security Policy in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Fast nostr web ui" />
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self'; child-src 'none'; worker-src 'self'; frame-src youtube.com www.youtube.com https://platform.twitter.com https://embed.tidal.com https://w.soundcloud.com https://www.mixcloud.com https://open.spotify.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src wss://* 'self' https://*; img-src * data:; font-src https://fonts.gstatic.com; media-src *; script-src 'self' https://static.cloudflareinsights.com https://platform.twitter.com https://embed.tidal.com;" />
+    content="default-src 'self'; child-src 'none'; worker-src 'self'; frame-src youtube.com www.youtube.com https://platform.twitter.com https://embed.tidal.com https://w.soundcloud.com https://www.mixcloud.com https://open.spotify.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src wss: 'self' https:; img-src * data:; font-src https://fonts.gstatic.com; media-src *; script-src 'self' https://static.cloudflareinsights.com https://platform.twitter.com https://embed.tidal.com;" />
 
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/nostrich_512.png" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />


### PR DESCRIPTION
Currently, the `connect-src` defined in `index.html` only allows connections to the default port of the `wss:`/`https:` scheme, namely port 443.
This change will allow connections to a relay using the port other than 443.