### PR TITLE
Support HTML Auto Directional Textual Content

### DIFF
--- a/src/Element/Text.tsx
+++ b/src/Element/Text.tsx
@@ -128,7 +128,7 @@ export default function Text({ content, tags, creator, users }: TextProps) {
   function transformParagraph(frag: TextFragment) {
     const fragments = transformText(frag);
     if (fragments.every(f => typeof f === "string")) {
-      return <p>{fragments}</p>;
+      return <p dir="auto">{fragments}</p>;
     }
     return <>{fragments}</>;
   }

--- a/src/Element/Textarea.tsx
+++ b/src/Element/Textarea.tsx
@@ -72,6 +72,7 @@ const Textarea = (props: TextareaProps) => {
   return (
     // @ts-expect-error If anybody can figure out how to type this, please do
     <ReactTextareaAutocomplete
+      dir="auto"
       {...props}
       loadingComponent={() => <span>Loading...</span>}
       placeholder={formatMessage(messages.NotePlaceholder)}

--- a/src/Pages/ProfilePage.tsx
+++ b/src/Pages/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import "./ProfilePage.css";
-import { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useIntl, FormattedMessage } from "react-intl";
 import { useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
@@ -150,10 +150,12 @@ export default function ProfilePage() {
 
   function bio() {
     return (
-      aboutText.length > 0 && (
-        <>
-          <div className="details">{about}</div>
-        </>
+      aboutText.length && (
+        <React.Fragment>
+          <div dir="auto" className="details">
+            {about}
+          </div>
+        </React.Fragment>
       )
     );
   }


### PR DESCRIPTION
# Problem
Texts that should be directed RTL are displayed TLR, which makes it inappropriate looking.
as it's requested by some users [user request](https://snort.social/e/note1h08vd3dd2m2e3wgr8jvnhuc2t5fnp0wjwq5mrv0egw9j8wxgr3rqpw0mte)

# Before
![image](https://user-images.githubusercontent.com/67356781/218381565-ff92a127-6be3-4e94-b3a7-30c10c37dda1.png)

# Solution
Allowing users' browsers to determine the direction side automatically in accordance with its content

```
<p dir="auto">...</p>
```

# After
![image](https://user-images.githubusercontent.com/67356781/218381329-6258fbef-b903-4adb-b797-063aeca331e0.png)
