### PR TITLE
Fix blackout when selecting global tab

### DIFF
--- a/packages/app/src/Pages/Root.tsx
+++ b/packages/app/src/Pages/Root.tsx
@@ -84,11 +84,10 @@ export default function RootPage() {
     return { type: "pubkey", items: follows, discriminator: "follows" };
   })();
 
-  if (isGlobal && globalRelays.length === 0) return null;
   return (
     <>
       <div className="main-content">{pubKey && <Tabs tabs={tabs} tab={tab} setTab={setTab} />}</div>
-      {isGlobal && (
+      {isGlobal && globalRelays.length > 0 && (
         <div className="flex mb10">
           <div className="f-grow">
             <FormattedMessage


### PR DESCRIPTION
This PR fixes a bug that caused the app to blackout when a user who has not registered any Paid Relay selects the global tab. 

before:
![before](https://user-images.githubusercontent.com/38322494/218780761-e1a3a740-2453-4742-933d-d005a4f54c17.png)

after: 
![after](https://user-images.githubusercontent.com/38322494/218781057-1e4df491-282b-4431-b857-33e297d7a0fa.png)

this account has only `wss://relay.damus.io`.
