### PR TITLE
Prevent profile text from overflowing flex container when it is too long

### DIFF
--- a/packages/app/src/Element/Nip05.tsx
+++ b/packages/app/src/Element/Nip05.tsx
@@ -59,7 +59,7 @@ const Nip05 = ({ nip05, pubkey, verifyNip = true }: Nip05Params) => {
       {!isDefaultUser && isVerified && <span className="nick">{`${name}@`}</span>}
       {isVerified && (
         <>
-          <span className="domain f-ellipsis" data-domain={domain?.toLowerCase()}>
+          <span className="domain" data-domain={domain?.toLowerCase()}>
             {domain}
           </span>
           <Badge className="badge" />

--- a/packages/app/src/Element/ProfileImage.tsx
+++ b/packages/app/src/Element/ProfileImage.tsx
@@ -53,7 +53,7 @@ export default function ProfileImage({
   };
 
   return (
-    <div className={`pfp${className ? ` ${className}` : ""}`}>
+    <div className={`pfp f-ellipsis${className ? ` ${className}` : ""}`}>
       <div className="avatar-wrapper">
         <Avatar user={user} onClick={onAvatarClick} />
       </div>


### PR DESCRIPTION
The long profile text was overflowing of the box, so move the `f-ellipsis` to the proper.
This works for both the display name and NIP-05.

ref: https://snort.social/e/note1gp6dy9w7j4qh6asemt9ptdk4c04qfdse6dwsj296p3zlk2zy6fvqjf9ffz

before:
![スクリーンショット 2023-02-15 2 54 17](https://user-images.githubusercontent.com/38322494/218820990-2974591a-7e0d-4625-84d6-52bcd86142a2.png)

after:
![スクリーンショット 2023-02-15 2 54 31](https://user-images.githubusercontent.com/38322494/218821205-f31070b4-6292-4907-9e5e-d810393531b8.png)

