### PR TITLE
Improve overflow menu button

### DIFF
--- a/packages/app/src/Element/Note.css
+++ b/packages/app/src/Element/Note.css
@@ -218,3 +218,15 @@
 .note .reactions-link:hover {
   text-decoration: underline;
 }
+
+.close-menu {
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  top: -400px;
+  left: -600px;
+}
+
+.close-menu-container {
+  position: absolute;
+}

--- a/packages/app/src/Element/Note.css
+++ b/packages/app/src/Element/Note.css
@@ -144,9 +144,11 @@
 
 .reaction-pill {
   display: flex;
-  flex-direction: row;
-  margin: 0px 14px;
-  min-width: 16px;
+  margin: 0px 7px;
+  padding: 2px 4px;
+  min-width: 1rem;
+  align-items: center;
+  justify-content: center;
   user-select: none;
   color: var(--font-secondary-color);
   font-feature-settings: "tnum";

--- a/packages/app/src/Element/Note.css
+++ b/packages/app/src/Element/Note.css
@@ -144,14 +144,16 @@
 
 .reaction-pill {
   display: flex;
-  margin: 0px 7px;
-  padding: 2px 4px;
-  min-width: 1rem;
-  align-items: center;
-  justify-content: center;
+  flex-direction: row;
+  margin: 0px 14px;
+  min-width: 16px;
   user-select: none;
   color: var(--font-secondary-color);
   font-feature-settings: "tnum";
+}
+
+.reaction-pill-icon {
+  margin: auto;
 }
 
 .reaction-pill .reaction-pill-number {

--- a/packages/app/src/Element/NoteFooter.tsx
+++ b/packages/app/src/Element/NoteFooter.tsx
@@ -209,6 +209,13 @@ export default function NoteFooter(props: NoteFooterProps) {
   function menuItems() {
     return (
       <>
+        <div className="close-menu-container">
+          {/* This menu item serves as a "close menu" button;
+          it allows the user to click anywhere nearby the menu to close it. */}
+          <MenuItem>
+            <div className="close-menu" />
+          </MenuItem>
+        </div>
         {prefs.enableReactions && (
           <MenuItem onClick={() => setShowReactions(true)}>
             <Heart />


### PR DESCRIPTION
In order to address https://github.com/v0l/snort/issues/177, I tried adding a background menu item which closes the sub-menu. I made this menu item cover a large area near the sub-menu. If a user clicks within this area, it will close the menu rather than performing the action underneath.

Rather than cover the whole page, I kept the size smaller. If a user scrolls away from the open sub-menu, they can still interact with other buttons and features.

I also increased the width of the three vertical dots menu button, so that its easier to click. Its current width is 4px, I increased this to 16px.

Here is a visual of the component, I temporarily set the color to blue so it is visible:

https://user-images.githubusercontent.com/14062229/218881434-0f46a7b9-2ac7-4241-b70e-2a0876497eb4.mov


