### PR TITLE
Reduce space between the texts for selecting relays

### DIFF
--- a/packages/app/src/Pages/Root.tsx
+++ b/packages/app/src/Pages/Root.tsx
@@ -88,22 +88,19 @@ export default function RootPage() {
     <>
       <div className="main-content">{pubKey && <Tabs tabs={tabs} tab={tab} setTab={setTab} />}</div>
       {isGlobal && globalRelays.length > 0 && (
-        <div className="flex mb10">
-          <div className="f-grow">
-            <FormattedMessage
-              defaultMessage="Read global from"
-              description="Label for reading global feed from specific relays"
-            />
-          </div>
-          <div>
-            <select onChange={e => setRelay(e.target.value)}>
-              {globalRelays.map(a => (
-                <option key={a} value={a}>
-                  {new URL(a).host}
-                </option>
-              ))}
-            </select>
-          </div>
+        <div className="flex mb10 f-end">
+          <FormattedMessage
+            defaultMessage="Read global from"
+            description="Label for reading global feed from specific relays"
+          />
+          &nbsp;
+          <select onChange={e => setRelay(e.target.value)}>
+            {globalRelays.map(a => (
+              <option key={a} value={a}>
+                {new URL(a).host}
+              </option>
+            ))}
+          </select>
         </div>
       )}
       {followHints()}

--- a/packages/app/src/Pages/Root.tsx
+++ b/packages/app/src/Pages/Root.tsx
@@ -86,23 +86,25 @@ export default function RootPage() {
 
   return (
     <>
-      <div className="main-content">{pubKey && <Tabs tabs={tabs} tab={tab} setTab={setTab} />}</div>
-      {isGlobal && globalRelays.length > 0 && (
-        <div className="flex mb10 f-end">
-          <FormattedMessage
-            defaultMessage="Read global from"
-            description="Label for reading global feed from specific relays"
-          />
-          &nbsp;
-          <select onChange={e => setRelay(e.target.value)}>
-            {globalRelays.map(a => (
-              <option key={a} value={a}>
-                {new URL(a).host}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
+      <div className="main-content">
+        {pubKey && <Tabs tabs={tabs} tab={tab} setTab={setTab} />}
+        {isGlobal && globalRelays.length > 0 && (
+          <div className="flex mb10 f-end">
+            <FormattedMessage
+              defaultMessage="Read global from"
+              description="Label for reading global feed from specific relays"
+            />
+            &nbsp;
+            <select onChange={e => setRelay(e.target.value)}>
+              {globalRelays.map(a => (
+                <option key={a} value={a}>
+                  {new URL(a).host}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
       {followHints()}
       <Timeline
         key={tab.value}


### PR DESCRIPTION
I think the spacing between `Read global from` and `[globalRelay]` is large and a bit misleading. Especially in Japanese, I thought.

after:
![after](https://user-images.githubusercontent.com/38322494/219222273-9b6510e6-35a2-420f-876e-935365760ef8.png)

