### PR TITLE
fix long zap comment text overflow

### DIFF
--- a/packages/app/src/Element/Reactions.css
+++ b/packages/app/src/Element/Reactions.css
@@ -92,6 +92,10 @@
   line-height: 17px;
 }
 
+.reactions-item .zap-comment {
+  width: 332px;
+}
+
 @media (max-width: 520px) {
   .reactions-view .tab.disabled {
     display: none;

--- a/packages/app/src/Element/Reactions.tsx
+++ b/packages/app/src/Element/Reactions.tsx
@@ -113,7 +113,11 @@ const Reactions = ({ show, setShow, positive, negative, reposts, zaps }: Reactio
                     <ProfileImage
                       autoWidth={false}
                       pubkey={z.anonZap ? "" : z.zapper}
-                      subHeader={<>{z.content}</>}
+                      subHeader={
+                        <div className="f-ellipsis zap-comment" title={z.content}>
+                          {z.content}
+                        </div>
+                      }
                       overrideUsername={z.anonZap ? formatMessage({ defaultMessage: "Anonymous" }) : undefined}
                     />
                   </div>


### PR DESCRIPTION
resolves https://github.com/v0l/snort/issues/342

The full text of the comment is shown in a popup when hovering over the text.

![Screenshot 2023-02-21 at 2 19 56 PM](https://user-images.githubusercontent.com/3655410/220450326-910fac4a-2993-484f-8de9-86d88be14ce5.png)
