### PR TITLE
fix links that end with a dash

### DIFF
--- a/packages/app/src/Const.ts
+++ b/packages/app/src/Const.ts
@@ -89,7 +89,7 @@ export const EmailRegex =
  */
 export const UrlRegex =
   // eslint-disable-next-line no-useless-escape
-  /((?:http|ftp|https):\/\/(?:[\w+?\.\w+])+(?:[a-zA-Z0-9\~\!\@\#\$\%\^\&\*\(\)_\-\=\+\\\/\?\.\:\;\'\,]*(?<!\)))\b\/?)/i;
+  /((?:http|ftp|https):\/\/(?:[\w+?\.\w+])+(?:[a-zA-Z0-9\~\!\@\#\$\%\^\&\*\(\)_\-\=\+\\\/\?\.\:\;\'\,]*(?<![).])))/i;
 
 /**
  * Extract file extensions regex


### PR DESCRIPTION
This fixes URLs that end with dashes, but it doesn't render an embed for YouTube clips like the one posted here https://snort.social/e/note1qftjaj66tyu2ppsq62tscld96pll5agjczzjw4qy8l4enrjn968s4wjwgx. Does YouTube have embeds for YouTube clips?