### PR TITLE
Revert "Merge pull request #347 from v0l/fix-links-in-parentheses"

### DIFF
--- a/packages/app/src/Const.ts
+++ b/packages/app/src/Const.ts
@@ -89,7 +89,7 @@ export const EmailRegex =
  */
 export const UrlRegex =
   // eslint-disable-next-line no-useless-escape
-  /((?:http|ftp|https):\/\/(?:[\w+?\.\w+])+(?:[a-zA-Z0-9\~\!\@\#\$\%\^\&\*\(\)_\-\=\+\\\/\?\.\:\;\'\,]*(?<!\)))\b\/?)/i;
+  /((?:http|ftp|https):\/\/(?:[\w+?\.\w+])+(?:[a-zA-Z0-9\~\!\@\#\$\%\^\&\*\(\)_\-\=\+\\\/\?\.\:\;\'\,]*)?)/i;
 
 /**
  * Extract file extensions regex


### PR DESCRIPTION
This regex seems to cause problems in some browsers. Reverting back to what it was before for now.