### PR TITLE
Update thread detection to not include mentions

### DIFF
--- a/packages/nostr/src/legacy/Thread.ts
+++ b/packages/nostr/src/legacy/Thread.ts
@@ -19,7 +19,7 @@ export default class Thread {
    * @param ev Event to extract thread from
    */
   static ExtractThread(ev: NEvent) {
-    const isThread = ev.Tags.some((a) => a.Key === "e");
+    const isThread = ev.Tags.some((a) => a.Key === "e" && a.Marker !== "mention");
     if (!isThread) {
       return null;
     }


### PR DESCRIPTION
Noticed 're:' was being added to notes in the UI when it only mentioned a note. This didn't constitute a thread and shouldn't attempt to add who it is replying to in the UI since there wasn't a reply to display. This simply makes sure that a thread is detected when there is an 'e' tag and the marker for the tag is not a mention.