### PR TITLE
Change message unread color to purple

### DIFF
--- a/packages/app/src/Element/UnreadCount.css
+++ b/packages/app/src/Element/UnreadCount.css
@@ -10,7 +10,7 @@
 }
 
 .pill.unread {
-  background-color: var(--gray);
+  background-color: var(--highlight);
   color: var(--font-color);
 }
 


### PR DESCRIPTION
This is more of a suggestion. Not a bug. I've noticed when looking at alot of DMs, though the unread background color is different, it's not different enough to make it easy to see what messages have unreads. So I updated the color to be the purple highlight color so it sticks out more. 

Before:

![image](https://user-images.githubusercontent.com/3712883/221285921-733eda31-fd13-4990-bfbd-823ff371e55b.png)

After:

![image](https://user-images.githubusercontent.com/3712883/221285970-f3445a33-c4d3-4eb1-a4cb-39c2fa5bf464.png)
