### PR TITLE
Remove unread message dot when messages all read

### DIFF
--- a/packages/app/src/Pages/Layout.tsx
+++ b/packages/app/src/Pages/Layout.tsx
@@ -29,8 +29,17 @@ export default function Layout() {
   const [show, setShow] = useState(false);
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { loggedOut, publicKey, relays, latestNotification, readNotifications, dms, preferences, newUserKey } =
-    useSelector((s: RootState) => s.login);
+  const {
+    loggedOut,
+    publicKey,
+    relays,
+    latestNotification,
+    readNotifications,
+    dms,
+    preferences,
+    newUserKey,
+    dmInteraction,
+  } = useSelector((s: RootState) => s.login);
   const { isMuted } = useModeration();
   const [pageClass, setPageClass] = useState("page");
   const pub = useEventPublisher();
@@ -66,7 +75,7 @@ export default function Layout() {
             publicKey
           )
         : 0,
-    [dms, publicKey]
+    [dms, publicKey, dmInteraction]
   );
 
   useEffect(() => {


### PR DESCRIPTION
Clicking the Mark All Read button was clearing the messages, but the purple dot was not disappearing until the page was refreshed. It appears it was just because the calculation was being cached and not updated because the dm interaction counter was not inputted as a dependency to useMemo