### PR TITLE
feat: add search page field autofocus

### DIFF
--- a/packages/app/src/Pages/SearchPage.tsx
+++ b/packages/app/src/Pages/SearchPage.tsx
@@ -56,6 +56,7 @@ const SearchPage = () => {
           placeholder={formatMessage(messages.SearchPlaceholder)}
           value={search}
           onChange={e => setSearch(e.target.value)}
+          autofocus
         />
       </div>
       {keyword && allUsers?.slice(0, 3).map(u => <ProfilePreview actions={<></>} className="card" pubkey={u.pubkey} />)}


### PR DESCRIPTION
This PR adds the `autofocus` attribute to the search field input element on the search page. This improves the UX especially when a user is searching and adding multiple users in a row.