### PR TITLE
Feat/add spinner to button

### DIFF
--- a/packages/app/src/Element/AsyncButton.css
+++ b/packages/app/src/Element/AsyncButton.css
@@ -1,0 +1,27 @@
+button {
+  position: relative;
+}
+
+.spinner {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation-name: spin;
+  animation-duration: 800ms;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/app/src/Element/AsyncButton.css
+++ b/packages/app/src/Element/AsyncButton.css
@@ -2,7 +2,7 @@ button {
   position: relative;
 }
 
-.spinner {
+.spinner-wrapper {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -11,17 +11,4 @@ button {
   display: flex;
   justify-content: center;
   align-items: center;
-  animation-name: spin;
-  animation-duration: 800ms;
-  animation-iteration-count: infinite;
-  animation-timing-function: linear;
-}
-
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
 }

--- a/packages/app/src/Element/AsyncButton.tsx
+++ b/packages/app/src/Element/AsyncButton.tsx
@@ -8,25 +8,19 @@ interface AsyncButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>
 }
 
 interface LoaderProps {
-  className: string
+  className: string;
 }
 
-const Loader = ({ className }: LoaderProps ) => (
+const Loader = ({ className }: LoaderProps) => (
   <div className={className}>
-    <svg
-      width="13"
-      height="14"
-      viewBox="0 0 13 14"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
+    <svg width="13" height="14" viewBox="0 0 13 14" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M4.38798 12.616C3.36313 12.2306 2.46328 11.5721 1.78592 10.7118C1.10856 9.85153 0.679515 8.82231   0.545268 7.73564C0.411022 6.64897 0.576691 5.54628 1.02433 4.54704C1.47197 3.54779 2.1845 2.69009 3.08475   2.06684C3.98499 1.4436 5.03862 1.07858 6.13148 1.01133C7.22435 0.944078 8.31478 1.17716 9.28464    1.68533C10.2545 2.19349 11.0668 2.95736 11.6336 3.89419C12.2004 4.83101 12.5 5.90507 12.5 7"
         stroke="white"
       />
     </svg>
   </div>
-)
+);
 
 export default function AsyncButton(props: AsyncButtonProps) {
   const [loading, setLoading] = useState<boolean>(false);
@@ -48,7 +42,7 @@ export default function AsyncButton(props: AsyncButtonProps) {
 
   return (
     <button type="button" disabled={loading || props.disabled} {...props} onClick={handle}>
-      <span style={{visibility: (loading ? "hidden" : "visible")}}>{props.children}</span>
+      <span style={{ visibility: loading ? "hidden" : "visible" }}>{props.children}</span>
       {loading && <Loader className="spinner" />}
     </button>
   );

--- a/packages/app/src/Element/AsyncButton.tsx
+++ b/packages/app/src/Element/AsyncButton.tsx
@@ -2,6 +2,7 @@ import "./AsyncButton.css";
 import { useState } from "react";
 
 interface AsyncButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  disabled?: boolean;
   onClick(e: React.MouseEvent): Promise<void> | void;
   children?: React.ReactNode;
 }
@@ -31,7 +32,7 @@ export default function AsyncButton(props: AsyncButtonProps) {
   const [loading, setLoading] = useState<boolean>(false);
 
   async function handle(e: React.MouseEvent) {
-    if (loading) return;
+    if (loading || props.disabled) return;
     setLoading(true);
     try {
       if (typeof props.onClick === "function") {
@@ -46,7 +47,7 @@ export default function AsyncButton(props: AsyncButtonProps) {
   }
 
   return (
-    <button type="button" disabled={loading} {...props} onClick={handle}>
+    <button type="button" disabled={loading || props.disabled} {...props} onClick={handle}>
       <span style={{visibility: (loading ? "hidden" : "visible")}}>{props.children}</span>
       {loading && <Loader className="spinner" />}
     </button>

--- a/packages/app/src/Element/AsyncButton.tsx
+++ b/packages/app/src/Element/AsyncButton.tsx
@@ -1,26 +1,12 @@
 import "./AsyncButton.css";
 import { useState } from "react";
+import Spinner from "../Icons/Spinner";
 
 interface AsyncButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   disabled?: boolean;
   onClick(e: React.MouseEvent): Promise<void> | void;
   children?: React.ReactNode;
 }
-
-interface LoaderProps {
-  className: string;
-}
-
-const Loader = ({ className }: LoaderProps) => (
-  <div className={className}>
-    <svg width="13" height="14" viewBox="0 0 13 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M4.38798 12.616C3.36313 12.2306 2.46328 11.5721 1.78592 10.7118C1.10856 9.85153 0.679515 8.82231   0.545268 7.73564C0.411022 6.64897 0.576691 5.54628 1.02433 4.54704C1.47197 3.54779 2.1845 2.69009 3.08475   2.06684C3.98499 1.4436 5.03862 1.07858 6.13148 1.01133C7.22435 0.944078 8.31478 1.17716 9.28464    1.68533C10.2545 2.19349 11.0668 2.95736 11.6336 3.89419C12.2004 4.83101 12.5 5.90507 12.5 7"
-        stroke="white"
-      />
-    </svg>
-  </div>
-);
 
 export default function AsyncButton(props: AsyncButtonProps) {
   const [loading, setLoading] = useState<boolean>(false);
@@ -41,9 +27,13 @@ export default function AsyncButton(props: AsyncButtonProps) {
   }
 
   return (
-    <button type="button" disabled={loading || props.disabled} {...props} onClick={handle}>
+    <button className="spinner-button" type="button" disabled={loading || props.disabled} {...props} onClick={handle}>
       <span style={{ visibility: loading ? "hidden" : "visible" }}>{props.children}</span>
-      {loading && <Loader className="spinner" />}
+      {loading && (
+        <span className="spinner-wrapper">
+          <Spinner />
+        </span>
+      )}
     </button>
   );
 }

--- a/packages/app/src/Element/AsyncButton.tsx
+++ b/packages/app/src/Element/AsyncButton.tsx
@@ -1,9 +1,31 @@
+import "./AsyncButton.css";
 import { useState } from "react";
 
 interface AsyncButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   onClick(e: React.MouseEvent): Promise<void> | void;
   children?: React.ReactNode;
 }
+
+interface LoaderProps {
+  className: string
+}
+
+const Loader = ({ className }: LoaderProps ) => (
+  <div className={className}>
+    <svg
+      width="13"
+      height="14"
+      viewBox="0 0 13 14"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4.38798 12.616C3.36313 12.2306 2.46328 11.5721 1.78592 10.7118C1.10856 9.85153 0.679515 8.82231   0.545268 7.73564C0.411022 6.64897 0.576691 5.54628 1.02433 4.54704C1.47197 3.54779 2.1845 2.69009 3.08475   2.06684C3.98499 1.4436 5.03862 1.07858 6.13148 1.01133C7.22435 0.944078 8.31478 1.17716 9.28464    1.68533C10.2545 2.19349 11.0668 2.95736 11.6336 3.89419C12.2004 4.83101 12.5 5.90507 12.5 7"
+        stroke="white"
+      />
+    </svg>
+  </div>
+)
 
 export default function AsyncButton(props: AsyncButtonProps) {
   const [loading, setLoading] = useState<boolean>(false);
@@ -25,7 +47,8 @@ export default function AsyncButton(props: AsyncButtonProps) {
 
   return (
     <button type="button" disabled={loading} {...props} onClick={handle}>
-      {props.children}
+      <span style={{visibility: (loading ? "hidden" : "visible")}}>{props.children}</span>
+      {loading && <Loader className="spinner" />}
     </button>
   );
 }

--- a/packages/app/src/Pages/settings/Profile.tsx
+++ b/packages/app/src/Pages/settings/Profile.tsx
@@ -16,7 +16,7 @@ import { HexKey } from "@snort/nostr";
 import useFileUpload from "Upload";
 
 import messages from "./messages";
-import AsyncButton from '../../Element/AsyncButton';
+import AsyncButton from "../../Element/AsyncButton";
 
 export interface ProfileSettingsProps {
   avatar?: boolean;

--- a/packages/app/src/Pages/settings/Profile.tsx
+++ b/packages/app/src/Pages/settings/Profile.tsx
@@ -16,6 +16,7 @@ import { HexKey } from "@snort/nostr";
 import useFileUpload from "Upload";
 
 import messages from "./messages";
+import AsyncButton from '../../Element/AsyncButton';
 
 export interface ProfileSettingsProps {
   avatar?: boolean;
@@ -166,9 +167,9 @@ export default function ProfileSettings(props: ProfileSettingsProps) {
         <div className="form-group card">
           <div></div>
           <div>
-            <button type="button" onClick={() => saveProfile()}>
+            <AsyncButton onClick={() => saveProfile()}>
               <FormattedMessage {...messages.Save} />
-            </button>
+            </AsyncButton>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Some information on the implementation:

* I decided to use css style visibility to hide the button text, to keep the width of the button on changing the state to the loading spinner

* I am actually used to handling the loading state outside the loading button, in the component where the button is used and the data handling of the button callback is handled. The loading state is then just passed down to the button. This way there is more control over the loading state, because it can be set and unset bevor and after the async request.

As it is right now, I think the loading is reset by a re-render of the button.

So I think in the long run, I think it makes sense to have the loading state handled in the parent component and pass it down to the button. I would need to refactor alls 4 places where the AsyncButton is used. What do you think?

* Would it make sense to rename AsyncButton to LoaderButton or SpinnerButton?

* Should I also apply AsyncButton to /settings/relays "Save" button?

* I added a "disabled" property to the AsyncButton, for future use. Maybe a button should be disalbed, as long as form fields are not valid.