### PR TITLE
Add people search

### DIFF
--- a/packages/app/src/Element/Timeline.tsx
+++ b/packages/app/src/Element/Timeline.tsx
@@ -56,7 +56,8 @@ export default function Timeline({
     (nts: TaggedRawEvent[]) => {
       const a = [...nts];
       noSort || a.sort((a, b) => b.created_at - a.created_at);
-      return a?.filter(a => (postsOnly ? !a.tags.some(b => b[0] === "e") : true))
+      return a
+        ?.filter(a => (postsOnly ? !a.tags.some(b => b[0] === "e") : true))
         .filter(a => ignoreModeration || !isMuted(a.pubkey));
     },
     [postsOnly, noSort, muted, ignoreModeration]

--- a/packages/app/src/Element/Timeline.tsx
+++ b/packages/app/src/Element/Timeline.tsx
@@ -27,6 +27,7 @@ export interface TimelineProps {
   ignoreModeration?: boolean;
   window?: number;
   relay?: string;
+  noSort?: boolean;
 }
 
 /**
@@ -39,6 +40,7 @@ export default function Timeline({
   ignoreModeration = false,
   window: timeWindow,
   relay,
+  noSort = false,
 }: TimelineProps) {
   const { muted, isMuted } = useModeration();
   const dispatch = useDispatch();
@@ -52,12 +54,12 @@ export default function Timeline({
 
   const filterPosts = useCallback(
     (nts: TaggedRawEvent[]) => {
-      return [...nts]
-        .sort((a, b) => b.created_at - a.created_at)
-        ?.filter(a => (postsOnly ? !a.tags.some(b => b[0] === "e") : true))
+      const a = [...nts];
+      noSort || a.sort((a, b) => b.created_at - a.created_at);
+      return a?.filter(a => (postsOnly ? !a.tags.some(b => b[0] === "e") : true))
         .filter(a => ignoreModeration || !isMuted(a.pubkey));
     },
-    [postsOnly, muted, ignoreModeration]
+    [postsOnly, noSort, muted, ignoreModeration]
   );
 
   const mainFeed = useMemo(() => {

--- a/packages/app/src/Feed/TimelineFeed.ts
+++ b/packages/app/src/Feed/TimelineFeed.ts
@@ -35,10 +35,8 @@ export default function useTimelineFeed(subject: TimelineSubject, options: Timel
 
     const sub = new Subscriptions();
     sub.Id = `timeline:${subject.type}:${subject.discriminator}`;
-    if (subject.type === "profile_keyword")
-      sub.Kinds = new Set([EventKind.SetMetadata]);
-    else
-      sub.Kinds = new Set([EventKind.TextNote, EventKind.Repost]);
+    if (subject.type === "profile_keyword") sub.Kinds = new Set([EventKind.SetMetadata]);
+    else sub.Kinds = new Set([EventKind.TextNote, EventKind.Repost]);
     switch (subject.type) {
       case "pubkey": {
         sub.Authors = new Set(subject.items);

--- a/packages/app/src/Feed/TimelineFeed.ts
+++ b/packages/app/src/Feed/TimelineFeed.ts
@@ -103,7 +103,7 @@ export default function useTimelineFeed(subject: TimelineSubject, options: Timel
       subLatest.Since = Math.floor(new Date().getTime() / 1000);
     }
     return subLatest;
-  }, [pref, createSub, subject.type]);
+  }, [pref, createSub]);
 
   const latest = useSubscription(subRealtime, {
     leaveOpen: true,

--- a/packages/app/src/Feed/TimelineFeed.ts
+++ b/packages/app/src/Feed/TimelineFeed.ts
@@ -91,7 +91,7 @@ export default function useTimelineFeed(subject: TimelineSubject, options: Timel
       }
     }
     return sub;
-  }, [until, since, options.method, pref, createSub, subject.type]);
+  }, [until, since, options.method, pref, createSub]);
 
   const main = useSubscription(sub, { leaveOpen: true, cache: subject.type !== "global", relay: options.relay });
 

--- a/packages/app/src/Feed/TimelineFeed.ts
+++ b/packages/app/src/Feed/TimelineFeed.ts
@@ -51,7 +51,7 @@ export default function useTimelineFeed(subject: TimelineSubject, options: Timel
         break;
       }
       case "profile_keyword": {
-        sub.Search = subject.items[0] + " sort:popular";
+        sub.Search = subject.items[0];
         break;
       }
       case "post_keyword": {

--- a/packages/app/src/Feed/TimelineFeed.ts
+++ b/packages/app/src/Feed/TimelineFeed.ts
@@ -35,8 +35,7 @@ export default function useTimelineFeed(subject: TimelineSubject, options: Timel
 
     const sub = new Subscriptions();
     sub.Id = `timeline:${subject.type}:${subject.discriminator}`;
-    if (subject.type === "profile_keyword") sub.Kinds = new Set([EventKind.SetMetadata]);
-    else sub.Kinds = new Set([EventKind.TextNote, EventKind.Repost]);
+    sub.Kinds = new Set([EventKind.TextNote, EventKind.Repost]);
     switch (subject.type) {
       case "pubkey": {
         sub.Authors = new Set(subject.items);
@@ -51,6 +50,7 @@ export default function useTimelineFeed(subject: TimelineSubject, options: Timel
         break;
       }
       case "profile_keyword": {
+        sub.Kinds = new Set([EventKind.SetMetadata]);
         sub.Search = subject.items[0];
         break;
       }

--- a/packages/app/src/Pages/SearchPage.tsx
+++ b/packages/app/src/Pages/SearchPage.tsx
@@ -9,7 +9,6 @@ import { SearchRelays } from "Const";
 import { System } from "System";
 
 import messages from "./messages";
-import useHorizontalScroll from "Hooks/useHorizontalScroll";
 
 const POSTS = 0;
 const PROFILES = 1;
@@ -25,7 +24,6 @@ const SearchPage = () => {
     Profiles: { text: formatMessage(messages.People), value: PROFILES },
   };
   const [tab, setTab] = useState<Tab>(SearchTab.Posts);
-  const horizontalScroll = useHorizontalScroll();
 
   useEffect(() => {
     if (keyword) {

--- a/packages/app/src/Pages/SearchPage.tsx
+++ b/packages/app/src/Pages/SearchPage.tsx
@@ -53,7 +53,6 @@ const SearchPage = () => {
     };
   }, []);
 
-
   function tabContent() {
     if (!keyword) return null;
     const pf = tab.value == PROFILES;

--- a/packages/app/src/Pages/SearchPage.tsx
+++ b/packages/app/src/Pages/SearchPage.tsx
@@ -90,7 +90,7 @@ const SearchPage = () => {
           autoFocus={true}
         />
       </div>
-      <div className="tabs" ref={horizontalScroll}>
+      <div className="tabs">
         {[SearchTab.Posts, SearchTab.Profiles].map(renderTab)}
       </div>
       {tabContent()}

--- a/packages/app/src/Pages/SearchPage.tsx
+++ b/packages/app/src/Pages/SearchPage.tsx
@@ -18,6 +18,7 @@ const SearchPage = () => {
   const { formatMessage } = useIntl();
   const [search, setSearch] = useState<string>();
   const [keyword, setKeyword] = useState<string | undefined>(params.keyword);
+  const [sortPopular, setSortPopular] = useState<boolean>(true);
   // tabs
   const SearchTab = {
     Posts: { text: formatMessage(messages.Posts), value: POSTS },
@@ -56,18 +57,37 @@ const SearchPage = () => {
     const pf = tab.value == PROFILES;
     return (
       <>
+        {sortOptions()}
         <Timeline
           key={keyword + (pf ? "_p" : "")}
           subject={{
             type: pf ? "profile_keyword" : "post_keyword",
-            items: [keyword],
+            items: [keyword + (sortPopular ? " sort:popular" : "")],
             discriminator: keyword,
           }}
           postsOnly={false}
-          noSort={pf}
+          noSort={pf && sortPopular}
           method={"LIMIT_UNTIL"}
         />
       </>
+    );
+  }
+
+  function sortOptions() {
+    if (tab.value != PROFILES) return null;
+    return (
+      <div className="flex mb10 f-end">
+        <FormattedMessage defaultMessage="Sort" description="Label for sorting options for people search" />
+        &nbsp;
+        <select onChange={e => setSortPopular(e.target.value == "true")} value={sortPopular ? "true" : "false"}>
+          <option value={"true"}>
+            <FormattedMessage defaultMessage="Popular" description="Sort order name" />
+          </option>
+          <option value={"false"}>
+            <FormattedMessage defaultMessage="Recent" description="Sort order name" />
+          </option>
+        </select>
+      </div>
     );
   }
 
@@ -90,9 +110,7 @@ const SearchPage = () => {
           autoFocus={true}
         />
       </div>
-      <div className="tabs">
-        {[SearchTab.Posts, SearchTab.Profiles].map(renderTab)}
-      </div>
+      <div className="tabs">{[SearchTab.Posts, SearchTab.Profiles].map(renderTab)}</div>
       {tabContent()}
     </div>
   );

--- a/packages/app/src/Pages/messages.ts
+++ b/packages/app/src/Pages/messages.ts
@@ -47,4 +47,5 @@ export default defineMessages({
   Bookmarks: { defaultMessage: "Bookmarks" },
   BookmarksCount: { defaultMessage: "{n} Bookmarks" },
   KeyPlaceholder: { defaultMessage: "nsec, npub, nip-05, hex" },
+  People: { defaultMessage: "People" },
 });


### PR DESCRIPTION
Trying to implement useful people search where results are ordered by 'popularity', not kind 0 update recency.

To enable the popularity sorting, I append " sort:popular" to the "search" filter - a way to pass options in NIP-50. I also have to disable loading of 'latest' events for this feed, bcs latest don't fit this sort order. And I had to use LIMIT_UNTIL and increase limit to 100 for this feed bcs scanning back with 'until' makes no sense with this sort order. And I had to disable the sorting by created_at, bcs of this sort order.

So it's a hack on a hack on a hack. Results look decent, but I don't like how it was achieved. 

Please take a look, maybe you'd have some suggestions.