### PR TITLE
fix icons

### DIFF
--- a/packages/app/src/Element/NoteFooter.tsx
+++ b/packages/app/src/Element/NoteFooter.tsx
@@ -277,7 +277,7 @@ export default function NoteFooter(props: NoteFooterProps) {
           </MenuItem>
         )}
         <MenuItem onClick={() => copyId()}>
-          <Icon name="dislike" />
+          <Icon name="copy" />
           <FormattedMessage {...messages.CopyID} />
         </MenuItem>
         <MenuItem onClick={() => mute(ev.PubKey)}>
@@ -286,7 +286,7 @@ export default function NoteFooter(props: NoteFooterProps) {
         </MenuItem>
         {prefs.enableReactions && (
           <MenuItem onClick={() => react("-")}>
-            <Icon name="copy" />
+            <Icon name="dislike" />
             <FormattedMessage {...messages.DislikeAction} />
           </MenuItem>
         )}


### PR DESCRIPTION
The icons in note footer have been switched unexpectedly.

<img width="244" alt="image" src="https://user-images.githubusercontent.com/38322494/222918969-6cbfb531-a045-45ce-8d17-3d73ca13b17d.png">
