### PR TITLE
fix(skeleton): dark theme styles

### DIFF
--- a/packages/app/src/Element/Skeleton.css
+++ b/packages/app/src/Element/Skeleton.css
@@ -3,8 +3,12 @@
   height: 1em;
   position: relative;
   overflow: hidden;
-  background-color: #dddbdd;
+  background-color: var(--note-bg);
   border-radius: 16px;
+}
+
+html.light .skeleton {
+  background-color: var(--gray-secondary);
 }
 
 .skeleton::after {
@@ -17,26 +21,26 @@
   background-image: linear-gradient(
     90deg,
     rgba(255, 255, 255, 0) 0,
-    rgba(255, 255, 255, 0.2) 20%,
-    rgba(255, 255, 255, 0.5) 60%,
+    rgba(255, 255, 255, 0.02) 20%,
+    rgba(255, 255, 255, 0.05) 60%,
     rgba(255, 255, 255, 0)
   );
   animation: shimmer 2s infinite;
   content: "";
 }
 
+html.light .skeleton::after {
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0,
+    rgba(255, 255, 255, 0.2) 20%,
+    rgba(255, 255, 255, 0.5) 60%,
+    rgba(255, 255, 255, 0)
+  );
+}
+
 @keyframes shimmer {
   100% {
     transform: translateX(100%);
-  }
-}
-
-@media screen and (prefers-color-scheme: dark) {
-  .skeleton {
-    background-color: #50535a;
-  }
-
-  .skeleton::after {
-    background-image: linear-gradient(90deg, #50535a 0%, #656871 20%, #50535a 40%, #50535a 100%);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/v0l/snort/issues/381 

The skeleton component had css that addressed the dark theme, this `prefers-color-scheme` media query had no effect however.

* change `prefers-color-scheme` to `html.light` selector
* improve styles for dark theme

<img width="734" alt="Bildschirmfoto 2023-03-04 um 11 37 37" src="https://user-images.githubusercontent.com/886152/222920618-fe15a39f-9a24-4379-833e-fe5b5ade3e75.png">
