### PR TITLE
feat(note): open note in new tab on cmd press

### DIFF
--- a/packages/app/src/Element/Note.tsx
+++ b/packages/app/src/Element/Note.tsx
@@ -175,7 +175,12 @@ export default function Note(props: NoteProps) {
 
   function goToEvent(e: React.MouseEvent, id: u256) {
     e.stopPropagation();
-    navigate(eventLink(id));
+    // detect cmd key and open in new tab
+    if (e.metaKey) {
+      window.open(eventLink(id), "_blank");
+    } else {
+      navigate(eventLink(id));
+    }
   }
 
   function replyTag() {


### PR DESCRIPTION
Fixes https://github.com/v0l/snort/issues/366

* detect macOS "cmd" key in click event and open note in new tab

This would be a first easy step to enable opening notes in new tabs.

As a follow up, right click functionality could be enabled. After quick research this would probably require default a tags, which deviate from the react logic of navigating which might break other functionality. 