### PR TITLE
fix HyperText matching

### DIFF
--- a/packages/app/src/Element/Text.tsx
+++ b/packages/app/src/Element/Text.tsx
@@ -35,7 +35,7 @@ export default function Text({ content, tags, creator }: TextProps) {
       .map(f => {
         if (typeof f === "string") {
           return splitByUrl(f).map(a => {
-            if (a.startsWith("http")) {
+            if (a.match(/^https?:\/\//)) {
               return <HyperText key={a} link={a} creator={creator} />;
             }
             return a;


### PR DESCRIPTION
When the text is:

```
http-is-great!
```

splitByUrl return `["http-is-great!"]` correctly but it always become hyper link since that does only checking only startsWith("http").

https://snort.social/e/note1dvng6smhrn5hxn8wcmyfutngusa7fqpxh93xnx8gal6w9ljjkjmss8qfu2