### PR TITLE
Add Wavlake embed

### DIFF
--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Fast nostr web ui" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; child-src 'none'; worker-src 'self'; frame-src youtube.com www.youtube.com https://platform.twitter.com https://embed.tidal.com https://w.soundcloud.com https://www.mixcloud.com https://open.spotify.com https://player.twitch.tv https://embed.music.apple.com https://nostrnests.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src *; img-src * data:; font-src https://fonts.gstatic.com; media-src *; script-src 'self' 'wasm-unsafe-eval' https://static.cloudflareinsights.com https://platform.twitter.com https://embed.tidal.com;" />
+      content="default-src 'self'; child-src 'none'; worker-src 'self'; frame-src youtube.com www.youtube.com https://platform.twitter.com https://embed.tidal.com https://w.soundcloud.com https://www.mixcloud.com https://open.spotify.com https://player.twitch.tv https://embed.music.apple.com https://nostrnests.com https://player.wavlake.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src *; img-src * data:; font-src https://fonts.gstatic.com; media-src *; script-src 'self' 'wasm-unsafe-eval' https://static.cloudflareinsights.com https://platform.twitter.com https://embed.tidal.com;" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/packages/app/src/Const.ts
+++ b/packages/app/src/Const.ts
@@ -165,3 +165,9 @@ export const NostrNestsRegex = /nostrnests\.com\/[a-zA-Z0-9]+/i;
  * Magnet link parser
  */
 export const MagnetRegex = /(magnet:[\S]+)/i;
+
+/**
+ * Wavlake embed regex
+ */
+export const WavlakeRegex =
+  /player\.wavlake\.com\/(track)\/([.a-zA-Z0-9-]+)/;

--- a/packages/app/src/Const.ts
+++ b/packages/app/src/Const.ts
@@ -169,5 +169,4 @@ export const MagnetRegex = /(magnet:[\S]+)/i;
 /**
  * Wavlake embed regex
  */
-export const WavlakeRegex =
-  /player\.wavlake\.com\/(track)\/([.a-zA-Z0-9-]+)/;
+export const WavlakeRegex = /player\.wavlake\.com\/(track)\/([.a-zA-Z0-9-]+)/;

--- a/packages/app/src/Element/HyperText.tsx
+++ b/packages/app/src/Element/HyperText.tsx
@@ -15,6 +15,7 @@ import {
   TwitchRegex,
   AppleMusicRegex,
   NostrNestsRegex,
+  WavlakeRegex
 } from "Const";
 import { RootState } from "State/Store";
 import SoundCloudEmbed from "Element/SoundCloudEmded";
@@ -25,6 +26,7 @@ import { ProxyImg } from "Element/ProxyImg";
 import TwitchEmbed from "Element/TwitchEmbed";
 import AppleMusicEmbed from "Element/AppleMusicEmbed";
 import NostrNestsEmbed from "Element/NostrNestsEmbed";
+import WavlakeEmbed from "Element/WavlakeEmbed";
 
 export default function HyperText({ link, creator }: { link: string; creator: HexKey }) {
   const pref = useSelector((s: RootState) => s.login.preferences);
@@ -70,6 +72,7 @@ export default function HyperText({ link, creator }: { link: string; creator: He
       const isTwitchLink = TwitchRegex.test(a);
       const isAppleMusicLink = AppleMusicRegex.test(a);
       const isNostrNestsLink = NostrNestsRegex.test(a);
+      const isWavlakeLink = WavlakeRegex.test(a);
       const extension = FileExtensionRegex.test(url.pathname.toLowerCase()) && RegExp.$1;
       if (extension && !isAppleMusicLink) {
         switch (extension) {
@@ -144,6 +147,8 @@ export default function HyperText({ link, creator }: { link: string; creator: He
           </a>,
           <NostrNestsEmbed link={a} />,
         ];
+      } else if (isWavlakeLink) {
+        return <WavlakeEmbed link={a} />;
       } else {
         return (
           <a href={a} onClick={e => e.stopPropagation()} target="_blank" rel="noreferrer" className="ext">

--- a/packages/app/src/Element/HyperText.tsx
+++ b/packages/app/src/Element/HyperText.tsx
@@ -15,7 +15,7 @@ import {
   TwitchRegex,
   AppleMusicRegex,
   NostrNestsRegex,
-  WavlakeRegex
+  WavlakeRegex,
 } from "Const";
 import { RootState } from "State/Store";
 import SoundCloudEmbed from "Element/SoundCloudEmded";

--- a/packages/app/src/Element/WavlakeEmbed.tsx
+++ b/packages/app/src/Element/WavlakeEmbed.tsx
@@ -1,0 +1,16 @@
+const WavlakeEmbed = ({ link }: { link: string }) => {
+  const convertedUrl = link.replace(/\/(track)\/([a-zA-Z0-9]+)/, "/embed/$1/$2");
+
+  return (
+    <iframe
+      style={{ borderRadius: 12 }}
+      src={convertedUrl}
+      width="100%"
+      height="360"
+      frameBorder="0"
+      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+      loading="lazy"></iframe>
+  );
+};
+
+export default WavlakeEmbed;


### PR DESCRIPTION
This enables the display of an embedded music player when people share links to tracks on Wavlake. The embedded player also is capable of boosting the track if the Alby extension (WebLN) is available and the wallet is capable of sending keysends. The boost button is not visible if WebLN is not available.

<img width="637" alt="Screenshot 2023-03-08 at 5 31 08 PM" src="https://user-images.githubusercontent.com/77257032/223877215-0ebee103-e8c3-44ca-b9f9-957531b82212.png">
