### PR TITLE
Fix event mention bug

### DIFF
--- a/packages/app/src/Element/Text.tsx
+++ b/packages/app/src/Element/Text.tsx
@@ -81,13 +81,15 @@ export default function Text({ content, tags, creator }: TextProps) {
                   }
                   case "e": {
                     const eText = hexToBech32("note", ref.Event).substring(0, 12);
-                    return (
+                    return ref.Event ? (
                       <Link
-                        to={eventLink(ref.Event ?? "")}
+                        to={eventLink(ref.Event)}
                         onClick={e => e.stopPropagation()}
                         state={{ from: location.pathname }}>
                         #{eText}
                       </Link>
+                    ) : (
+                      ""
                     );
                   }
                   case "t": {

--- a/packages/app/src/Feed/EventPublisher.ts
+++ b/packages/app/src/Feed/EventPublisher.ts
@@ -76,7 +76,7 @@ export default function useEventPublisher() {
     };
     const content = msg
       .replace(/@npub[a-z0-9]+/g, replaceNpub)
-      .replace(/note[a-z0-9]+/g, replaceNoteId)
+      .replace(/note1[acdefghjklmnpqrstuvwxyz023456789]{58}/g, replaceNoteId)
       .replace(HashtagRegex, replaceHashtag);
     ev.Content = content;
   }


### PR DESCRIPTION
resolves https://github.com/v0l/snort/issues/418

![Screenshot 2023-03-09 at 3 03 44 PM](https://user-images.githubusercontent.com/3655410/224157405-71bfcaa4-e11a-4d20-84bc-1aaf985db301.png)

```json
{
  "content": "Testing that the word notes doesn't turn into an event mention, but nip-19 note ID does turn into a mention #[0]",
  "created_at": 1678395675,
  "id": "ee5f7877ee0bab89be86e5a04f005001dfddcb5a0f75240e773b1979e80e8304",
  "kind": 1,
  "pubkey": "cf5d1fa43cfb08f3d14bd6af9f71e68eff6359fbd8028cfcea4ab38dfbf595de",
  "sig": "b7e0fea93c23f5064012927287adeb76e9be0d2ed9026113cd9879abe72d8261a6f40200447088d55304ee5a32ecab0ac52219eeaa28795f87bcbd1ae4ac6971",
  "tags": [
    [
      "e",
      "06b4abc93c300a98b5230fab289ffbbf722f6bea22dfd5c8ce6a27315706c280",
      "",
      "mention"
    ]
  ],
  "relays": [
    "wss://offchain.pub"
  ]
}
```
