### PR TITLE
Added key attr to Tabs to remove React warning

### DIFF
--- a/packages/app/src/Element/Tabs.tsx
+++ b/packages/app/src/Element/Tabs.tsx
@@ -32,7 +32,7 @@ const Tabs = ({ tabs, tab, setTab }: TabsProps) => {
   return (
     <div className="tabs" ref={horizontalScroll}>
       {tabs.map(t => (
-        <TabElement tab={tab} setTab={setTab} t={t} />
+        <TabElement key={t.value} tab={tab} setTab={setTab} t={t} />
       ))}
     </div>
   );


### PR DESCRIPTION
While working on something else, I noticed a warning in the console about the Tabs not having unique `key` attributes. This just adds that to shut React up. I doubt any performance increases actually come from this. :laughing: 