### PR TITLE
fix: private key strength should be 256 bits.

### DIFF
--- a/packages/app/src/Util.ts
+++ b/packages/app/src/Util.ts
@@ -106,7 +106,7 @@ export function hexToBech32(hrp: string, hex?: string) {
 
 export function generateBip39Entropy(mnemonic?: string): Uint8Array {
   try {
-    const mn = mnemonic ?? bip39.generateMnemonic(wordlist);
+    const mn = mnemonic ?? bip39.generateMnemonic(wordlist, 256);
     return bip39.mnemonicToEntropy(mn, wordlist);
   } catch (e) {
     throw new Error("INVALID MNEMONIC PHRASE");


### PR DESCRIPTION
Added signature.

---

Hi! Thank you for creating a great client!

I think I found an issue about NIP-06 PR #425.

`bip39.generateMnemonic(wordlist)` generates 128 bit strength private keys.
In my opinion, it should be 256 bit if you replace `secp.utils.randomPrivateKey()` which generates 32 byte (256bit) private keys.