### PR TITLE
only replace note ID when note ID starts with `@` character

### DIFF
--- a/packages/app/src/Feed/EventPublisher.ts
+++ b/packages/app/src/Feed/EventPublisher.ts
@@ -58,7 +58,7 @@ export default function useEventPublisher() {
         return match;
       }
     };
-    const replaceNoteId = (match: string) => {
+    const replaceNoteId = (_: string, match: string) => {
       try {
         const hex = bech32ToHex(match);
         const idx = ev.Tags.length;
@@ -76,7 +76,7 @@ export default function useEventPublisher() {
     };
     const content = msg
       .replace(/@npub[a-z0-9]+/g, replaceNpub)
-      .replace(/note1[acdefghjklmnpqrstuvwxyz023456789]{58}/g, replaceNoteId)
+      .replace(/\s(note1[acdefghjklmnpqrstuvwxyz023456789]{58})\s/g, replaceNoteId)
       .replace(HashtagRegex, replaceHashtag);
     ev.Content = content;
   }

--- a/packages/app/src/Feed/EventPublisher.ts
+++ b/packages/app/src/Feed/EventPublisher.ts
@@ -76,7 +76,7 @@ export default function useEventPublisher() {
     };
     const content = msg
       .replace(/@npub[a-z0-9]+/g, replaceNpub)
-      .replace(/(\s)(note1[acdefghjklmnpqrstuvwxyz023456789]{58})(\s)/g, replaceNoteId)
+      .replace(/(\s)@{0,1}(note1[acdefghjklmnpqrstuvwxyz023456789]{58})(\s)/g, replaceNoteId)
       .replace(HashtagRegex, replaceHashtag);
     ev.Content = content;
   }

--- a/packages/app/src/Feed/EventPublisher.ts
+++ b/packages/app/src/Feed/EventPublisher.ts
@@ -58,14 +58,14 @@ export default function useEventPublisher() {
         return match;
       }
     };
-    const replaceNoteId = (_: string, match: string) => {
+    const replaceNoteId = (_: string, before: string, noteId: string, after: string) => {
       try {
-        const hex = bech32ToHex(match);
+        const hex = bech32ToHex(noteId);
         const idx = ev.Tags.length;
         ev.Tags.push(new Tag(["e", hex, "", "mention"], idx));
-        return `#[${idx}]`;
+        return `${before}#[${idx}]${after}`;
       } catch (error) {
-        return match;
+        return _;
       }
     };
     const replaceHashtag = (match: string) => {
@@ -76,7 +76,7 @@ export default function useEventPublisher() {
     };
     const content = msg
       .replace(/@npub[a-z0-9]+/g, replaceNpub)
-      .replace(/\s(note1[acdefghjklmnpqrstuvwxyz023456789]{58})\s/g, replaceNoteId)
+      .replace(/(\s)(note1[acdefghjklmnpqrstuvwxyz023456789]{58})(\s)/g, replaceNoteId)
       .replace(HashtagRegex, replaceHashtag);
     ev.Content = content;
   }

--- a/packages/app/src/Feed/EventPublisher.ts
+++ b/packages/app/src/Feed/EventPublisher.ts
@@ -58,12 +58,13 @@ export default function useEventPublisher() {
         return match;
       }
     };
-    const replaceNoteId = (match: string, before: string, noteId: string, after: string) => {
+    const replaceNoteId = (match: string) => {
+      const noteId = match.slice(1);
       try {
         const hex = bech32ToHex(noteId);
         const idx = ev.Tags.length;
         ev.Tags.push(new Tag(["e", hex, "", "mention"], idx));
-        return `${before}#[${idx}]${after}`;
+        return `#[${idx}]`;
       } catch (error) {
         return match;
       }
@@ -76,7 +77,7 @@ export default function useEventPublisher() {
     };
     const content = msg
       .replace(/@npub[a-z0-9]+/g, replaceNpub)
-      .replace(/(\s)@{0,1}(note1[acdefghjklmnpqrstuvwxyz023456789]{58})(\s)/g, replaceNoteId)
+      .replace(/@note1[acdefghjklmnpqrstuvwxyz023456789]{58}/g, replaceNoteId)
       .replace(HashtagRegex, replaceHashtag);
     ev.Content = content;
   }

--- a/packages/app/src/Feed/EventPublisher.ts
+++ b/packages/app/src/Feed/EventPublisher.ts
@@ -58,14 +58,14 @@ export default function useEventPublisher() {
         return match;
       }
     };
-    const replaceNoteId = (_: string, before: string, noteId: string, after: string) => {
+    const replaceNoteId = (match: string, before: string, noteId: string, after: string) => {
       try {
         const hex = bech32ToHex(noteId);
         const idx = ev.Tags.length;
         ev.Tags.push(new Tag(["e", hex, "", "mention"], idx));
         return `${before}#[${idx}]${after}`;
       } catch (error) {
-        return _;
+        return match;
       }
     };
     const replaceHashtag = (match: string) => {


### PR DESCRIPTION
resolves https://github.com/v0l/snort/issues/440


![Screenshot 2023-03-14 at 3 39 16 PM](https://user-images.githubusercontent.com/3655410/225131160-8bdd6416-c4b9-4e5a-aa57-1d4b578794b2.png)


```json
{
  "id": "d098bbfc7fb36cc5204012ad5db7b624e77f934f98cfd39301409c7838e0cca3",
  "pubkey": "03e20803e8917f3ba4e029e6fcd2a3c1b97cdd7c691119c1bdf4bb7543e4e1c1",
  "created_at": 1678826024,
  "kind": 1,
  "tags": [
    [
      "e",
      "d5dc392fc5b381c526182ffdfda0ddfc4eca0b67eedbb4179bfc9f1d9bb3c7c0",
      "",
      "mention"
    ]
  ],
  "content": "Note IDs should be replaced with a tag: \n#[0]\nOther text such as link that contain note IDs should not be replaced with a tag:\n\nhttps://snort.social/e/note16hwrjt79kwqu2fsc9l7lmgxal38v5zm8amdmg9umlj03mxanclqqn7k634\n\n",
  "sig": "4e5166ff2a0a78679b01b1e71c35522cbfc481bfa76336f0ca9b938ced463a918e29966ea3d39745bc0a550ace4f1dc7ea0c46c20cace5e83f9843590707b8a4",
  "relays": [
    "wss://nostr-relay.alekberg.net"
  ]
}
```