### PR TITLE
Display search property alongside host in relay name

### DIFF
--- a/packages/app/src/Element/Relay.tsx
+++ b/packages/app/src/Element/Relay.tsx
@@ -18,6 +18,7 @@ import { RootState } from "State/Store";
 import { RelaySettings } from "@snort/nostr";
 
 import messages from "./messages";
+import { getRelayName } from "Util";
 
 export interface RelayProps {
   addr: string;
@@ -30,7 +31,7 @@ export default function Relay(props: RelayProps) {
   const allRelaySettings = useSelector<RootState, Record<string, RelaySettings>>(s => s.login.relays);
   const relaySettings = allRelaySettings[props.addr];
   const state = useRelayState(props.addr);
-  const name = useMemo(() => new URL(props.addr).host, [props.addr]);
+  const name = useMemo(() => getRelayName(props.addr), [props.addr]);
 
   function configure(o: RelaySettings) {
     dispatch(

--- a/packages/app/src/Pages/Root.tsx
+++ b/packages/app/src/Pages/Root.tsx
@@ -9,7 +9,7 @@ import { RootState } from "State/Store";
 import Timeline from "Element/Timeline";
 import { System } from "System";
 import { TimelineSubject } from "Feed/TimelineFeed";
-import { debounce, sha256, unwrap } from "Util";
+import { debounce, getRelayName, sha256, unwrap } from "Util";
 
 import messages from "./messages";
 
@@ -87,7 +87,7 @@ export default function RootPage() {
             <optgroup label="Paid Relays">
               {paidRelays.map(a => (
                 <option key={a.url} value={a.url}>
-                  {new URL(a.url).host}
+                  {getRelayName(a.url)}
                 </option>
               ))}
             </optgroup>
@@ -95,7 +95,7 @@ export default function RootPage() {
           <optgroup label="Public Relays">
             {publicRelays.map(a => (
               <option key={a.url} value={a.url}>
-                {new URL(a.url).host}
+                {getRelayName(a.url)}
               </option>
             ))}
           </optgroup>

--- a/packages/app/src/Util.test.ts
+++ b/packages/app/src/Util.test.ts
@@ -1,4 +1,4 @@
-import { splitByUrl, magnetURIDecode } from "./Util";
+import { splitByUrl, magnetURIDecode, getRelayName } from "./Util";
 
 describe("splitByUrl", () => {
   it("should split a string by URLs", () => {
@@ -54,5 +54,24 @@ describe("magnet", () => {
       "udp://tracker.example2.com:80",
       "udp://tracker.example1.com:1337",
     ]);
+  });
+});
+
+describe("getRelayName", () => {
+  it("should return relay name", () => {
+    const url = "wss://relay.snort.social/";
+    const output = getRelayName(url);
+    expect(output).toEqual("relay.snort.social");
+  });
+  it("should return relay name with search property", () => {
+    const url = "wss://relay.example1.com/?lang=en";
+    const output = getRelayName(url);
+    expect(output).toEqual("relay.example1.com?lang=en");
+  });
+  it("should return relay name without pathname", () => {
+    const url =
+      "wss://relay.example2.com/npub1sn0rtcjcf543gj4wsg7fa59s700d5ztys5ctj0g69g2x6802npjqhjjtws?broadcast=true";
+    const output = getRelayName(url);
+    expect(output).toEqual("relay.example2.com?broadcast=true");
   });
 });

--- a/packages/app/src/Util.ts
+++ b/packages/app/src/Util.ts
@@ -462,3 +462,8 @@ export async function hmacSha256(key: Uint8Array, ...messages: Uint8Array[]) {
     return hmac(hash, key, secp.utils.concatBytes(...messages));
   }
 }
+
+export function getRelayName(url: string) {
+  const parsedUrl = new URL(url);
+  return parsedUrl.host + parsedUrl.search;
+}


### PR DESCRIPTION
Updated relay names to include the search property in addition to the host in order to support relays that use query parameters for filtering, such as `universe.nostrich.land`.

before:
![before1](https://user-images.githubusercontent.com/38322494/227199405-f23b7e0f-a032-4e94-b420-291936ae8fd6.png)
![before2](https://user-images.githubusercontent.com/38322494/227199880-4bc41cbc-4212-4573-a691-3e0631abae00.png)

after:
![after1](https://user-images.githubusercontent.com/38322494/227199394-dddd0bb9-e23b-4c3f-a34a-45236f4d4732.png)
![after2](https://user-images.githubusercontent.com/38322494/227199870-8e45fe7b-f3c1-49c0-a1d0-eab3aa1075fe.png)


