### PR TITLE
Fix: invisible <option> text in dark theme

### DIFF
--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -292,6 +292,10 @@ textarea {
   border: 1px solid rgba(0, 0, 0, 0.3);
 }
 
+option, optgroup {
+  background-color: var(--bg-color);
+}
+
 input:placeholder,
 textarea:placeholder {
   color: var(--font-tertiary-color);

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -292,7 +292,8 @@ textarea {
   border: 1px solid rgba(0, 0, 0, 0.3);
 }
 
-option, optgroup {
+option,
+optgroup {
   background-color: var(--bg-color);
 }
 


### PR DESCRIPTION
## Description
In some environments, texts in `<option>`/`<optgroup>` elements are invisible if the dark theme is enabled.  This problem occurs because the text color matches with the background color accidentally.

I confirmed that this problem occurred in:
- Chrome on Windows 10
- Edge on Windows 10
- Chrome on Ubuntu 22.04
- Firefox on Ubuntu 22.04

Fixed it by setting `background-color` of these elements to `--bg-color`.

I confirmed that this fix won't break appearance in other environments, such as Safari/Chrome on macOS/iOS, Chrome on Android.

## Screenshots
### Before Fix
![snort_options_in_dark_theme](https://user-images.githubusercontent.com/12131273/227232007-f053415e-7c5b-4def-aa27-e01b71cdc89c.png)

### After Fix
![snort_options_in_dark_theme_fixed](https://user-images.githubusercontent.com/12131273/227233162-1e0c2b96-83aa-43ad-81bd-5f1f96a1dc79.png)
