### PR TITLE
Nostr links

### DIFF
--- a/packages/app/src/Element/Copy.tsx
+++ b/packages/app/src/Element/Copy.tsx
@@ -5,14 +5,15 @@ import { useCopy } from "useCopy";
 export interface CopyProps {
   text: string;
   maxSize?: number;
+  className?: string;
 }
-export default function Copy({ text, maxSize = 32 }: CopyProps) {
+export default function Copy({ text, maxSize = 32, className }: CopyProps) {
   const { copy, copied } = useCopy();
   const sliceLength = maxSize / 2;
   const trimmed = text.length > maxSize ? `${text.slice(0, sliceLength)}...${text.slice(-sliceLength)}` : text;
 
   return (
-    <div className="flex flex-row copy" onClick={() => copy(text)}>
+    <div className={`flex flex-row copy ${className}`} onClick={() => copy(text)}>
       <span className="body">{trimmed}</span>
       <span className="icon" style={{ color: copied ? "var(--success)" : "var(--highlight)" }}>
         {copied ? <Icon name="check" size={14} /> : <Icon name="copy" size={14} />}

--- a/packages/app/src/Element/HyperText.tsx
+++ b/packages/app/src/Element/HyperText.tsx
@@ -27,6 +27,7 @@ import TwitchEmbed from "Element/TwitchEmbed";
 import AppleMusicEmbed from "Element/AppleMusicEmbed";
 import NostrNestsEmbed from "Element/NostrNestsEmbed";
 import WavlakeEmbed from "Element/WavlakeEmbed";
+import NostrLink from "Element/NostrLink";
 
 export default function HyperText({ link, creator }: { link: string; creator: HexKey }) {
   const pref = useSelector((s: RootState) => s.login.preferences);
@@ -149,6 +150,8 @@ export default function HyperText({ link, creator }: { link: string; creator: He
         ];
       } else if (isWavlakeLink) {
         return <WavlakeEmbed link={a} />;
+      } else if (url.protocol === "nostr:" || url.protocol === "web+nostr:") {
+        return <NostrLink link={a} />;
       } else {
         return (
           <a href={a} onClick={e => e.stopPropagation()} target="_blank" rel="noreferrer" className="ext">

--- a/packages/app/src/Element/Mention.tsx
+++ b/packages/app/src/Element/Mention.tsx
@@ -1,24 +1,20 @@
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { useUserProfile } from "Hooks/useUserProfile";
 import { HexKey } from "@snort/nostr";
-import { hexToBech32, profileLink } from "Util";
 
-export default function Mention({ pubkey }: { pubkey: HexKey }) {
+import { useUserProfile } from "Hooks/useUserProfile";
+import { profileLink } from "Util";
+import { getDisplayName } from "Element/ProfileImage";
+
+export default function Mention({ pubkey, relays }: { pubkey: HexKey; relays?: Array<string> | string }) {
   const user = useUserProfile(pubkey);
 
   const name = useMemo(() => {
-    let name = hexToBech32("npub", pubkey).substring(0, 12);
-    if (user?.display_name !== undefined && user.display_name.length > 0) {
-      name = user.display_name;
-    } else if (user?.name !== undefined && user.name.length > 0) {
-      name = user.name;
-    }
-    return name;
+    return getDisplayName(user, pubkey);
   }, [user, pubkey]);
 
   return (
-    <Link to={profileLink(pubkey)} onClick={e => e.stopPropagation()}>
+    <Link to={profileLink(pubkey, relays)} onClick={e => e.stopPropagation()}>
       @{name}
     </Link>
   );

--- a/packages/app/src/Element/NostrLink.tsx
+++ b/packages/app/src/Element/NostrLink.tsx
@@ -1,8 +1,8 @@
-import { encodeTLV, NostrPrefix } from "@snort/nostr";
+import { NostrPrefix } from "@snort/nostr";
 import { Link } from "react-router-dom";
 
 import Mention from "Element/Mention";
-import { parseNostrLink } from "Util";
+import { eventLink, parseNostrLink } from "Util";
 
 export default function NostrLink({ link }: { link: string }) {
   const nav = parseNostrLink(link);
@@ -10,11 +10,10 @@ export default function NostrLink({ link }: { link: string }) {
   if (nav?.type === NostrPrefix.PublicKey || nav?.type === NostrPrefix.Profile) {
     return <Mention pubkey={nav.id} relays={nav.relays} />;
   } else if (nav?.type === NostrPrefix.Note || nav?.type === NostrPrefix.Event) {
-    // translate all "event" links to nevent
-    const evLink = encodeTLV(nav.id, NostrPrefix.Event, nav.relays);
+    const evLink = eventLink(nav.id, nav.relays);
     return (
-      <Link to={`/e/${evLink}`} onClick={e => e.stopPropagation()} state={{ from: location.pathname }}>
-        #{evLink.substring(0, 12)}
+      <Link to={evLink} onClick={e => e.stopPropagation()} state={{ from: location.pathname }}>
+        #{evLink.split("/").at(-1)?.substring(0, 12)}
       </Link>
     );
   } else {

--- a/packages/app/src/Element/NostrLink.tsx
+++ b/packages/app/src/Element/NostrLink.tsx
@@ -1,0 +1,27 @@
+import { encodeTLV, NostrPrefix } from "@snort/nostr";
+import { Link } from "react-router-dom";
+
+import Mention from "Element/Mention";
+import { parseNostrLink } from "Util";
+
+export default function NostrLink({ link }: { link: string }) {
+  const nav = parseNostrLink(link);
+
+  if (nav?.type === NostrPrefix.PublicKey || nav?.type === NostrPrefix.Profile) {
+    return <Mention pubkey={nav.id} relays={nav.relays} />;
+  } else if (nav?.type === NostrPrefix.Note || nav?.type === NostrPrefix.Event) {
+    // translate all "event" links to nevent
+    const evLink = encodeTLV(nav.id, NostrPrefix.Event, nav.relays);
+    return (
+      <Link to={`/e/${evLink}`} onClick={e => e.stopPropagation()} state={{ from: location.pathname }}>
+        #{evLink.substring(0, 12)}
+      </Link>
+    );
+  } else {
+    return (
+      <a href={link} onClick={e => e.stopPropagation()} target="_blank" rel="noreferrer" className="ext">
+        {link}
+      </a>
+    );
+  }
+}

--- a/packages/app/src/Element/NoteFooter.tsx
+++ b/packages/app/src/Element/NoteFooter.tsx
@@ -3,14 +3,14 @@ import { useSelector, useDispatch } from "react-redux";
 import { useIntl, FormattedMessage } from "react-intl";
 import { Menu, MenuItem } from "@szhsin/react-menu";
 import { useLongPress } from "use-long-press";
-import { Event as NEvent, TaggedRawEvent, HexKey, u256 } from "@snort/nostr";
+import { Event as NEvent, TaggedRawEvent, HexKey, u256, encodeTLV, NostrPrefix } from "@snort/nostr";
 
 import Icon from "Icons/Icon";
 import Spinner from "Icons/Spinner";
 
 import { formatShort } from "Number";
 import useEventPublisher from "Feed/EventPublisher";
-import { bech32ToHex, delay, hexToBech32, normalizeReaction, unwrap } from "Util";
+import { bech32ToHex, delay, normalizeReaction, unwrap } from "Util";
 import { NoteCreator } from "Element/NoteCreator";
 import Reactions from "Element/Reactions";
 import SendSats from "Element/SendSats";
@@ -263,7 +263,8 @@ export default function NoteFooter(props: NoteFooterProps) {
   }
 
   async function share() {
-    const url = `${window.location.protocol}//${window.location.host}/e/${hexToBech32("note", ev.Id)}`;
+    const link = encodeTLV(ev.Id, NostrPrefix.Event, ev.Original?.relays);
+    const url = `${window.location.protocol}//${window.location.host}/e/${link}`;
     if ("share" in window.navigator) {
       await window.navigator.share({
         title: "Snort",
@@ -298,7 +299,8 @@ export default function NoteFooter(props: NoteFooterProps) {
   }
 
   async function copyId() {
-    await navigator.clipboard.writeText(hexToBech32("note", ev.Id));
+    const link = encodeTLV(ev.Id, NostrPrefix.Event, ev.Original?.relays);
+    await navigator.clipboard.writeText(link);
   }
 
   async function pin(id: HexKey) {

--- a/packages/app/src/Element/NoteReaction.tsx
+++ b/packages/app/src/Element/NoteReaction.tsx
@@ -2,7 +2,7 @@ import "./NoteReaction.css";
 import { Link } from "react-router-dom";
 import { useMemo } from "react";
 
-import { EventKind, Event as NEvent } from "@snort/nostr";
+import { EventKind, Event as NEvent, NostrPrefix } from "@snort/nostr";
 import Note from "Element/Note";
 import ProfileImage from "Element/ProfileImage";
 import { eventLink, hexToBech32 } from "Util";
@@ -24,7 +24,7 @@ export default function NoteReaction(props: NoteReactionProps) {
     if (ev) {
       const eTags = ev.Tags.filter(a => a.Key === "e");
       if (eTags.length > 0) {
-        return eTags[0].Event;
+        return eTags[0];
       }
     }
     return null;
@@ -34,7 +34,7 @@ export default function NoteReaction(props: NoteReactionProps) {
     ev.Kind !== EventKind.Reaction &&
     ev.Kind !== EventKind.Repost &&
     (ev.Kind !== EventKind.TextNote ||
-      ev.Tags.every((a, i) => a.Event !== refEvent || a.Marker !== "mention" || ev.Content !== `#[${i}]`))
+      ev.Tags.every((a, i) => a.Event !== refEvent?.Event || a.Marker !== "mention" || ev.Content !== `#[${i}]`))
   ) {
     return null;
   }
@@ -73,7 +73,9 @@ export default function NoteReaction(props: NoteReactionProps) {
       {root ? <Note data={root} options={opt} related={[]} /> : null}
       {!root && refEvent ? (
         <p>
-          <Link to={eventLink(refEvent)}>#{hexToBech32("note", refEvent).substring(0, 12)}</Link>
+          <Link to={eventLink(refEvent.Event ?? "", refEvent.Relay)}>
+            #{hexToBech32(NostrPrefix.Event, refEvent.Event).substring(0, 12)}
+          </Link>
         </p>
       ) : null}
     </div>

--- a/packages/app/src/Element/ProfileImage.tsx
+++ b/packages/app/src/Element/ProfileImage.tsx
@@ -6,7 +6,7 @@ import { useUserProfile } from "Hooks/useUserProfile";
 import { hexToBech32, profileLink } from "Util";
 import Avatar from "Element/Avatar";
 import Nip05 from "Element/Nip05";
-import { HexKey } from "@snort/nostr";
+import { HexKey, NostrPrefix } from "@snort/nostr";
 import { MetadataCache } from "State/Users";
 import usePageWidth from "Hooks/usePageWidth";
 
@@ -77,7 +77,7 @@ export default function ProfileImage({
 }
 
 export function getDisplayName(user: MetadataCache | undefined, pubkey: HexKey) {
-  let name = hexToBech32("npub", pubkey).substring(0, 12);
+  let name = hexToBech32(NostrPrefix.PublicKey, pubkey).substring(0, 12);
   if (user?.display_name !== undefined && user.display_name.length > 0) {
     name = user.display_name;
   } else if (user?.name !== undefined && user.name.length > 0) {

--- a/packages/app/src/Element/Text.tsx
+++ b/packages/app/src/Element/Text.tsx
@@ -4,7 +4,7 @@ import { Link, useLocation } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import { visit, SKIP } from "unist-util-visit";
 import * as unist from "unist";
-import { HexKey, Tag } from "@snort/nostr";
+import { HexKey, NostrPrefix, Tag } from "@snort/nostr";
 
 import { MentionRegex, InvoiceRegex, HashtagRegex, MagnetRegex } from "Const";
 import { eventLink, hexToBech32, magnetURIDecode, splitByUrl, unwrap } from "Util";
@@ -35,7 +35,7 @@ export default function Text({ content, tags, creator }: TextProps) {
       .map(f => {
         if (typeof f === "string") {
           return splitByUrl(f).map(a => {
-            if (a.match(/^https?:\/\//)) {
+            if (a.match(/^(?:https?|(?:web\+)?nostr):/i)) {
               return <HyperText key={a} link={a} creator={creator} />;
             }
             return a;
@@ -77,13 +77,13 @@ export default function Text({ content, tags, creator }: TextProps) {
               if (ref) {
                 switch (ref.Key) {
                   case "p": {
-                    return <Mention pubkey={ref.PubKey ?? ""} />;
+                    return <Mention pubkey={ref.PubKey ?? ""} relays={ref.Relay} />;
                   }
                   case "e": {
-                    const eText = hexToBech32("note", ref.Event).substring(0, 12);
+                    const eText = hexToBech32(NostrPrefix.Event, ref.Event).substring(0, 12);
                     return ref.Event ? (
                       <Link
-                        to={eventLink(ref.Event)}
+                        to={eventLink(ref.Event, ref.Relay)}
                         onClick={e => e.stopPropagation()}
                         state={{ from: location.pathname }}>
                         #{eText}

--- a/packages/app/src/Element/Textarea.tsx
+++ b/packages/app/src/Element/Textarea.tsx
@@ -5,6 +5,7 @@ import { useIntl } from "react-intl";
 import ReactTextareaAutocomplete from "@webscopeio/react-textarea-autocomplete";
 import emoji from "@jukben/emoji-search";
 import TextareaAutosize from "react-textarea-autosize";
+import { NostrPrefix } from "@snort/nostr";
 
 import Avatar from "Element/Avatar";
 import Nip05 from "Element/Nip05";
@@ -82,7 +83,7 @@ const Textarea = (props: TextareaProps) => {
           afterWhitespace: true,
           dataProvider: userDataProvider,
           component: (props: { entity: MetadataCache }) => <UserItem {...props.entity} />,
-          output: (item: { pubkey: string }) => `@${hexToBech32("npub", item.pubkey)}`,
+          output: (item: { pubkey: string }) => `@${hexToBech32(NostrPrefix.PublicKey, item.pubkey)}`,
         },
       }}
     />

--- a/packages/app/src/Element/Thread.tsx
+++ b/packages/app/src/Element/Thread.tsx
@@ -255,14 +255,14 @@ const TierThree = ({ active, path, isLastSubthread, from, notes, related, chains
 
 export interface ThreadProps {
   notes?: TaggedRawEvent[];
+  selected?: u256;
 }
 
 export default function Thread(props: ThreadProps) {
   const notes = props.notes ?? [];
   const parsedNotes = notes.map(a => new NEvent(a));
   const [path, setPath] = useState<HexKey[]>([]);
-  const currentId = path.length > 0 && path[path.length - 1];
-  const currentRoot = useMemo(() => parsedNotes.find(a => a.Id === currentId), [notes, currentId]);
+  const currentRoot = useMemo(() => parsedNotes.find(a => a.Id === props.selected), [notes, props.selected]);
   const [navigated, setNavigated] = useState(false);
   const navigate = useNavigate();
   const isSingleNote = parsedNotes.filter(a => a.Kind === EventKind.TextNote).length === 1;

--- a/packages/app/src/Feed/ThreadFeed.ts
+++ b/packages/app/src/Feed/ThreadFeed.ts
@@ -5,10 +5,10 @@ import useSubscription from "Feed/Subscription";
 import { useSelector } from "react-redux";
 import { RootState } from "State/Store";
 import { UserPreferences } from "State/Login";
-import { debounce } from "Util";
+import { debounce, NostrLink } from "Util";
 
-export default function useThreadFeed(id: u256) {
-  const [trackingEvents, setTrackingEvent] = useState<u256[]>([id]);
+export default function useThreadFeed(link: NostrLink) {
+  const [trackingEvents, setTrackingEvent] = useState<u256[]>([link.id]);
   const pref = useSelector<RootState, UserPreferences>(s => s.login.preferences);
 
   function addId(id: u256[]) {
@@ -25,7 +25,7 @@ export default function useThreadFeed(id: u256) {
 
   const sub = useMemo(() => {
     const thisSub = new Subscriptions();
-    thisSub.Id = `thread:${id.substring(0, 8)}`;
+    thisSub.Id = `thread:${link.id.substring(0, 8)}`;
     thisSub.Ids = new Set(trackingEvents);
 
     // get replies to this event
@@ -39,7 +39,7 @@ export default function useThreadFeed(id: u256) {
     thisSub.AddSubscription(subRelated);
 
     return thisSub;
-  }, [trackingEvents, pref, id]);
+  }, [trackingEvents, pref, link.id]);
 
   const main = useSubscription(sub, { leaveOpen: true, cache: true });
 

--- a/packages/app/src/Pages/EventPage.tsx
+++ b/packages/app/src/Pages/EventPage.tsx
@@ -1,12 +1,17 @@
 import { useParams } from "react-router-dom";
+
 import Thread from "Element/Thread";
 import useThreadFeed from "Feed/ThreadFeed";
-import { parseId } from "Util";
+import { parseNostrLink, unwrap } from "Util";
 
 export default function EventPage() {
   const params = useParams();
-  const id = parseId(params.id ?? "");
-  const thread = useThreadFeed(id);
+  const link = parseNostrLink(params.id ?? "");
+  const thread = useThreadFeed(unwrap(link));
 
-  return <Thread key={id} notes={thread.notes} />;
+  if (link) {
+    return <Thread key={link.id} notes={thread.notes} selected={link.id} />;
+  } else {
+    return <b>{params.id}</b>;
+  }
 }

--- a/packages/app/src/Pages/Login.tsx
+++ b/packages/app/src/Pages/Login.tsx
@@ -10,7 +10,8 @@ import { HexKey } from "@snort/nostr";
 import { RootState } from "State/Store";
 import { setPrivateKey, setPublicKey, setRelays, setGeneratedPrivateKey } from "State/Login";
 import { DefaultRelays, EmailRegex, MnemonicRegex } from "Const";
-import { bech32ToHex, generateBip39Entropy, entropyToDerivedKey, unwrap } from "Util";
+import { bech32ToHex, unwrap } from "Util";
+import { generateBip39Entropy, entropyToDerivedKey } from "nip6";
 import ZapButton from "Element/ZapButton";
 import useImgProxy from "Hooks/useImgProxy";
 

--- a/packages/app/src/Pages/new/NewUserFlow.tsx
+++ b/packages/app/src/Pages/new/NewUserFlow.tsx
@@ -6,7 +6,8 @@ import Logo from "Element/Logo";
 import { CollapsedSection } from "Element/Collapsed";
 import Copy from "Element/Copy";
 import { RootState } from "State/Store";
-import { hexToBech32, hexToMnemonic } from "Util";
+import { hexToBech32 } from "Util";
+import { hexToMnemonic } from "nip6";
 
 import messages from "./messages";
 

--- a/packages/app/src/Util.test.ts
+++ b/packages/app/src/Util.test.ts
@@ -31,6 +31,21 @@ describe("splitByUrl", () => {
     expect(splitByUrl(inputStr)).toEqual(expectedOutput);
   });
 
+  it("should parse nostr links", () => {
+    const input =
+      "web+nostr:npub1v0lxxxxutpvrelsksy8cdhgfux9l6a42hsj2qzquu2zk7vc9qnkszrqj49\nnostr:note1jp6d36lmquhxqn2s5n4ce00pzu2jrpkek8udav6l0y3qcdngpnxsle6ngm\nnostr:naddr1qqv8x6r0wf6x2um594cxzarg946x7ttpwajhxmmdv5pzqx78pgq53vlnzmdr8l3u38eru0n3438lnxqz0mr39wg9e5j0dfq3qvzqqqr4gu5d05rr\nnostr is cool";
+    const expected = [
+      "",
+      "web+nostr:npub1v0lxxxxutpvrelsksy8cdhgfux9l6a42hsj2qzquu2zk7vc9qnkszrqj49",
+      "\n",
+      "nostr:note1jp6d36lmquhxqn2s5n4ce00pzu2jrpkek8udav6l0y3qcdngpnxsle6ngm",
+      "\n",
+      "nostr:naddr1qqv8x6r0wf6x2um594cxzarg946x7ttpwajhxmmdv5pzqx78pgq53vlnzmdr8l3u38eru0n3438lnxqz0mr39wg9e5j0dfq3qvzqqqr4gu5d05rr",
+      "\nnostr is cool",
+    ];
+    expect(splitByUrl(input)).toEqual(expected);
+  });
+
   it("should return an array with a single string if no URLs are found", () => {
     const inputStr = "This is a regular string with no URLs";
     const expectedOutput = ["This is a regular string with no URLs"];

--- a/packages/app/src/nip6.ts
+++ b/packages/app/src/nip6.ts
@@ -1,0 +1,39 @@
+import * as secp from "@noble/secp256k1";
+import * as bip39 from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english";
+import { HDKey } from "@scure/bip32";
+
+import { DerivationPath } from "Const";
+
+export function generateBip39Entropy(mnemonic?: string): Uint8Array {
+  try {
+    const mn = mnemonic ?? bip39.generateMnemonic(wordlist, 256);
+    return bip39.mnemonicToEntropy(mn, wordlist);
+  } catch (e) {
+    throw new Error("INVALID MNEMONIC PHRASE");
+  }
+}
+
+/**
+ * Convert hex-encoded entropy into mnemonic phrase
+ */
+export function hexToMnemonic(hex: string): string {
+  const bytes = secp.utils.hexToBytes(hex);
+  return bip39.entropyToMnemonic(bytes, wordlist);
+}
+
+/**
+ * Convert mnemonic phrase into hex-encoded private key
+ * using the derivation path specified in NIP06
+ * @param mnemonic the mnemonic-encoded entropy
+ */
+export function entropyToDerivedKey(entropy: Uint8Array): string {
+  const masterKey = HDKey.fromMasterSeed(entropy);
+  const newKey = masterKey.derive(DerivationPath);
+
+  if (!newKey.privateKey) {
+    throw new Error("INVALID KEY DERIVATION");
+  }
+
+  return secp.utils.bytesToHex(newKey.privateKey);
+}

--- a/packages/nostr/src/legacy/Links.ts
+++ b/packages/nostr/src/legacy/Links.ts
@@ -11,6 +11,7 @@ export enum NostrPrefix {
   Profile = "nprofile",
   Event = "nevent",
   Relay = "nrelay",
+  Address = "naddr",
 }
 
 export enum TLVEntryType {
@@ -43,7 +44,7 @@ export function encodeTLV(hex: string, prefix: NostrPrefix, relays?: string[]) {
       })
       .flat() ?? [];
 
-  return bech32.encode(prefix, bech32.toWords([...tl0, ...tl1]));
+  return bech32.encode(prefix, bech32.toWords([...tl0, ...tl1]), 1_000);
 }
 
 export function decodeTLV(str: string) {


### PR DESCRIPTION
Use `nevent` / `nprofile` links when relay data is known

- Text notes ALWAYS have relay information so share links and clicking on threads will now always use `nevent` 
- When relay hints exist for `e` tags then `nevent` links will be created (mentions or `re:` tags in note header)
- `nostr:` or `web+nostr:` links will be parsed and converted into clickable links within snort (except `naddr`)
- Profile QR now uses `nprofile` as well as offering copy link

## Todo

- [ ] Relays data is currently not used yet when opening `nevent` / `nprofile`, i will add this in another PR when the core refactor is done (ephemeral connections support) 