### PR TITLE
Prevents adding ws relay when over https

### DIFF
--- a/packages/app/src/Pages/settings/Relays.tsx
+++ b/packages/app/src/Pages/settings/Relays.tsx
@@ -31,6 +31,14 @@ const RelaySettingsPage = () => {
     }
   }
 
+  const handleNewRelayChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = event.target.value;
+    const protocol = window.location.protocol;
+    if ((protocol === "https:" && inputValue.startsWith("wss://")) || protocol === "http:") {
+      setNewRelay(inputValue);
+    }
+  };
+
   function addRelay() {
     return (
       <>
@@ -43,7 +51,7 @@ const RelaySettingsPage = () => {
             className="f-grow"
             placeholder="wss://my-relay.com"
             value={newRelay}
-            onChange={e => setNewRelay(e.target.value)}
+            onChange={handleNewRelayChange}
           />
         </div>
         <button className="secondary mb10" onClick={() => addNewRelay()}>


### PR DESCRIPTION
It will help with https://github.com/v0l/snort/issues/451 

We can still connect to ws when running local snort. 