### PR TITLE
Update Wavlake embed to support .com links

### DIFF
--- a/packages/app/src/Const.ts
+++ b/packages/app/src/Const.ts
@@ -168,5 +168,4 @@ export const MagnetRegex = /(magnet:[\S]+)/i;
 /**
  * Wavlake embed regex
  */
-export const WavlakeRegex =
-  /player\.wavlake\.com\/(?!feed\/)(track\/[.a-zA-Z0-9-]+|album\/[.a-zA-Z0-9-]+|[.a-zA-Z0-9-]+)/i;
+export const WavlakeRegex = /(?:player\.)?wavlake\.com\/(track\/[.a-zA-Z0-9-]+|album\/[.a-zA-Z0-9-]+|[.a-zA-Z0-9-]+)/i;

--- a/packages/app/src/Element/WavlakeEmbed.tsx
+++ b/packages/app/src/Element/WavlakeEmbed.tsx
@@ -1,5 +1,5 @@
 const WavlakeEmbed = ({ link }: { link: string }) => {
-  const convertedUrl = link.replace("player.wavlake.com", "embed.wavlake.com");
+  const convertedUrl = link.replace(/(?:player\.)?wavlake\.com/, "embed.wavlake.com");
 
   return (
     <iframe


### PR DESCRIPTION
We just updated our site so that the music player lives on wavlake.com. This update allows Snort to render embeds correctly for tracks/albums/artists from both the legacy player.wavlake.com links as well as the new ones.