### PR TITLE
fix #485

### DIFF
--- a/packages/app/src/Element/Zap.tsx
+++ b/packages/app/src/Element/Zap.tsx
@@ -153,9 +153,11 @@ export const ZapsSummary = ({ zaps }: ZapsSummaryProps) => {
                 overrideUsername={anonZap ? formatMessage({ defaultMessage: "Anonymous" }) : undefined}
               />
             )}
-            {(restZaps.length > 0) ? 
+            {restZaps.length > 0 ? (
               <FormattedMessage {...messages.Others} values={{ n: restZaps.length }} />
-              : <FormattedMessage {...messages.Zapped}/>}{" "}
+            ) : (
+              <FormattedMessage {...messages.Zapped} />
+            )}{" "}
             <FormattedMessage {...messages.OthersZapped} values={{ n: restZaps.length }} />
           </div>
         </div>

--- a/packages/app/src/Element/Zap.tsx
+++ b/packages/app/src/Element/Zap.tsx
@@ -153,7 +153,9 @@ export const ZapsSummary = ({ zaps }: ZapsSummaryProps) => {
                 overrideUsername={anonZap ? formatMessage({ defaultMessage: "Anonymous" }) : undefined}
               />
             )}
-            {restZaps.length > 0 && <FormattedMessage {...messages.Others} values={{ n: restZaps.length }} />}{" "}
+            {(restZaps.length > 0) ? 
+              <FormattedMessage {...messages.Others} values={{ n: restZaps.length }} />
+              : <FormattedMessage {...messages.Zapped}/>}{" "}
             <FormattedMessage {...messages.OthersZapped} values={{ n: restZaps.length }} />
           </div>
         </div>


### PR DESCRIPTION
fixes bug #485

The issue was when exactly 1 zap exists for a note, we are not showing the text "zapped" (variable `restZaps` becomes 0 and we are not handing this case correctly)

Fixed the `restZaps`=0 case. 

Here's the screenshot with fix:

![image](https://user-images.githubusercontent.com/2035886/229854976-79a057e8-0172-4d66-9512-0df1f9071231.png)
