### PR TITLE
Update regex for Wavlake embeds, ignore zine subdomain

### DIFF
--- a/packages/app/src/Const.ts
+++ b/packages/app/src/Const.ts
@@ -177,4 +177,5 @@ export const MagnetRegex = /(magnet:[\S]+)/i;
 /**
  * Wavlake embed regex
  */
-export const WavlakeRegex = /(?:player\.)?wavlake\.com\/(track\/[.a-zA-Z0-9-]+|album\/[.a-zA-Z0-9-]+|[.a-zA-Z0-9-]+)/i;
+export const WavlakeRegex =
+  /(?!zine\.wavlake\.com)(?:player\.|www\.)?wavlake\.com\/(?:(?:track|album)\/[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}|[a-z-]+)$/i;

--- a/packages/app/src/Element/WavlakeEmbed.tsx
+++ b/packages/app/src/Element/WavlakeEmbed.tsx
@@ -1,5 +1,5 @@
 const WavlakeEmbed = ({ link }: { link: string }) => {
-  const convertedUrl = link.replace(/(?:player\.)?wavlake\.com/, "embed.wavlake.com");
+  const convertedUrl = link.replace(/(?:player\.|www\.)?wavlake\.com/, "embed.wavlake.com");
 
   return (
     <iframe


### PR DESCRIPTION
This fixes an issue where shares from our new zine subdomain are getting blanked out because the regex is incorrectly converting them to embed links.