### PR TITLE
feat: broadcast or rebroadcast note to specific relays

### DIFF
--- a/packages/app/src/Element/NoteCreator.tsx
+++ b/packages/app/src/Element/NoteCreator.tsx
@@ -370,7 +370,7 @@ export function NoteCreator() {
                 <FormattedMessage defaultMessage="Custom Relays" />
               </h4>
               <p>
-                <FormattedMessage defaultMessage="Send note to a subset of my write relays" />
+                <FormattedMessage defaultMessage="Send note to a subset of your write relays" />
               </p>
               {renderRelayCustomisation()}
               <h4>

--- a/packages/app/src/Element/NoteCreator.tsx
+++ b/packages/app/src/Element/NoteCreator.tsx
@@ -245,9 +245,7 @@ export function NoteCreator() {
         {Object.keys(relays.item || {}).filter((el) => relays.item[el].write).map((r,i,a) => 
           <div className="card flex">
             <div className="flex f-col f-grow">
-              <div>
-                <FormattedMessage defaultMessage="{relay}" values={{ relay:r }} />
-              </div>
+              <div>{r}</div>
             </div>
             <div>
               <input

--- a/packages/app/src/Element/NoteCreator.tsx
+++ b/packages/app/src/Element/NoteCreator.tsx
@@ -57,8 +57,20 @@ export function NoteCreator() {
   const { formatMessage } = useIntl();
   const publisher = useEventPublisher();
   const uploader = useFileUpload();
-  const { note, zapForward, sensitive, pollOptions, replyTo, otherEvents, preview, active, show, showAdvanced, selectedCustomRelays, error } =
-    useSelector((s: RootState) => s.noteCreator);
+  const {
+    note,
+    zapForward,
+    sensitive,
+    pollOptions,
+    replyTo,
+    otherEvents,
+    preview,
+    active,
+    show,
+    showAdvanced,
+    selectedCustomRelays,
+    error,
+  } = useSelector((s: RootState) => s.noteCreator);
   const [uploadInProgress, setUploadInProgress] = useState(false);
   const dispatch = useDispatch();
   const sub = getCurrentSubscription(LoginStore.allSubscriptions());
@@ -100,11 +112,11 @@ export function NoteCreator() {
         return eb;
       };
       const ev = replyTo ? await publisher.reply(replyTo, note, hk) : await publisher.note(note, hk);
-      if (selectedCustomRelays) publisher.broadcastAll(ev,selectedCustomRelays);
+      if (selectedCustomRelays) publisher.broadcastAll(ev, selectedCustomRelays);
       else publisher.broadcast(ev);
       dispatch(reset());
       for (const oe of otherEvents) {
-        if (selectedCustomRelays) publisher.broadcastAll(oe,selectedCustomRelays);
+        if (selectedCustomRelays) publisher.broadcastAll(oe, selectedCustomRelays);
         else publisher.broadcast(oe);
       }
       dispatch(reset());
@@ -238,33 +250,38 @@ export function NoteCreator() {
       dispatch(setPollOptions(copy));
     }
   }
-  
+
   function renderRelayCustomisation() {
     return (
       <div>
-        {Object.keys(relays.item || {}).filter((el) => relays.item[el].write).map((r,i,a) => 
-          <div className="card flex">
-            <div className="flex f-col f-grow">
-              <div>{r}</div>
+        {Object.keys(relays.item || {})
+          .filter(el => relays.item[el].write)
+          .map((r, i, a) => (
+            <div className="card flex">
+              <div className="flex f-col f-grow">
+                <div>{r}</div>
+              </div>
+              <div>
+                <input
+                  type="checkbox"
+                  checked={!selectedCustomRelays || selectedCustomRelays.includes(r)}
+                  onChange={e =>
+                    dispatch(
+                      setSelectedCustomRelays(
+                        // set false if all relays selected
+                        e.target.checked && selectedCustomRelays && selectedCustomRelays.length == a.length - 1
+                          ? false
+                          : // otherwise return selectedCustomRelays with target relay added / removed
+                            a.filter(el =>
+                              el === r ? e.target.checked : !selectedCustomRelays || selectedCustomRelays.includes(el)
+                            )
+                      )
+                    )
+                  }
+                />
+              </div>
             </div>
-            <div>
-              <input
-                type="checkbox"
-                checked={!selectedCustomRelays || selectedCustomRelays.includes(r)}
-                onChange={e => dispatch(setSelectedCustomRelays(
-                  // set false if all relays selected
-                  e.target.checked && selectedCustomRelays && selectedCustomRelays.length == a.length - 1
-                    ? false
-                  // otherwise return selectedCustomRelays with target relay added / removed 
-                    : a.filter((el) => el === r
-                    ? e.target.checked
-                    : !selectedCustomRelays || selectedCustomRelays.includes(el)
-                  )
-                ))}
-              />
-            </div>
-          </div>
-        )}
+          ))}
       </div>
     );
   }

--- a/packages/app/src/Element/NoteFooter.tsx
+++ b/packages/app/src/Element/NoteFooter.tsx
@@ -19,7 +19,11 @@ import { ParsedZap, ZapsSummary } from "Element/Zap";
 import { useUserProfile } from "Hooks/useUserProfile";
 import { RootState } from "State/Store";
 import { setReplyTo, setShow, reset } from "State/NoteCreator";
-import { setNote as setReBroadcastNote, setShow as setReBroadcastShow, reset as resetReBroadcast } from "State/ReBroadcast";
+import {
+  setNote as setReBroadcastNote,
+  setShow as setReBroadcastShow,
+  reset as resetReBroadcast,
+} from "State/ReBroadcast";
 import useModeration from "Hooks/useModeration";
 import { SnortPubKey, TranslateHost } from "Const";
 import { LNURL } from "LNURL";
@@ -437,7 +441,7 @@ export default function NoteFooter(props: NoteFooterProps) {
     if (reBroadcastNote?.id !== ev.id) {
       dispatch(resetReBroadcast());
     }
-    
+
     dispatch(setReBroadcastNote(ev));
     dispatch(setReBroadcastShow(!showReBroadcastModal));
   };

--- a/packages/app/src/Element/NoteFooter.tsx
+++ b/packages/app/src/Element/NoteFooter.tsx
@@ -12,12 +12,14 @@ import { formatShort } from "Number";
 import useEventPublisher from "Feed/EventPublisher";
 import { bech32ToHex, delay, normalizeReaction, unwrap } from "Util";
 import { NoteCreator } from "Element/NoteCreator";
+import { ReBroadcaster } from "Element/ReBroadcaster";
 import Reactions from "Element/Reactions";
 import SendSats from "Element/SendSats";
 import { ParsedZap, ZapsSummary } from "Element/Zap";
 import { useUserProfile } from "Hooks/useUserProfile";
 import { RootState } from "State/Store";
 import { setReplyTo, setShow, reset } from "State/NoteCreator";
+import { setNote as setReBroadcastNote, setShow as setReBroadcastShow, reset as resetReBroadcast } from "State/ReBroadcast";
 import useModeration from "Hooks/useModeration";
 import { SnortPubKey, TranslateHost } from "Const";
 import { LNURL } from "LNURL";
@@ -101,8 +103,11 @@ export default function NoteFooter(props: NoteFooterProps) {
   const author = useUserProfile(ev.pubkey);
   const publisher = useEventPublisher();
   const showNoteCreatorModal = useSelector((s: RootState) => s.noteCreator.show);
+  const showReBroadcastModal = useSelector((s: RootState) => s.reBroadcast.show);
+  const reBroadcastNote = useSelector((s: RootState) => s.reBroadcast.note);
   const replyTo = useSelector((s: RootState) => s.noteCreator.replyTo);
   const willRenderNoteCreator = showNoteCreatorModal && replyTo?.id === ev.id;
+  const willRenderReBroadcast = showReBroadcastModal && reBroadcastNote && reBroadcastNote?.id === ev.id;
   const [tip, setTip] = useState(false);
   const [zapping, setZapping] = useState(false);
   const walletState = useWallet();
@@ -387,10 +392,18 @@ export default function NoteFooter(props: NoteFooterProps) {
             <FormattedMessage {...messages.DislikeAction} />
           </MenuItem>
         )}
-        <MenuItem onClick={() => block(ev.pubkey)}>
-          <Icon name="block" />
-          <FormattedMessage {...messages.Block} />
-        </MenuItem>
+        {ev.pubkey === publicKey && (
+          <MenuItem onClick={handleReBroadcastButtonClick}>
+            <Icon name="relay" />
+            <FormattedMessage {...messages.ReBroadcast} />
+          </MenuItem>
+        )}
+        {ev.pubkey !== publicKey && (
+          <MenuItem onClick={() => block(ev.pubkey)}>
+            <Icon name="block" />
+            <FormattedMessage {...messages.Block} />
+          </MenuItem>
+        )}
         <MenuItem onClick={() => translate()}>
           <Icon name="translate" />
           <FormattedMessage {...messages.TranslateTo} values={{ lang: langNames.of(lang.split("-")[0]) }} />
@@ -420,6 +433,15 @@ export default function NoteFooter(props: NoteFooterProps) {
     dispatch(setShow(!showNoteCreatorModal));
   };
 
+  const handleReBroadcastButtonClick = () => {
+    if (reBroadcastNote?.id !== ev.id) {
+      dispatch(resetReBroadcast());
+    }
+    
+    dispatch(setReBroadcastNote(ev));
+    dispatch(setReBroadcastShow(!showReBroadcastModal));
+  };
+
   return (
     <>
       <div className="footer">
@@ -440,6 +462,7 @@ export default function NoteFooter(props: NoteFooterProps) {
           </Menu>
         </div>
         {willRenderNoteCreator && <NoteCreator />}
+        {willRenderReBroadcast && <ReBroadcaster />}
         <Reactions
           show={showReactions}
           setShow={setShowReactions}

--- a/packages/app/src/Element/ReBroadcaster.tsx
+++ b/packages/app/src/Element/ReBroadcaster.tsx
@@ -39,9 +39,7 @@ export function ReBroadcaster() {
         {Object.keys(relays.item || {}).filter((el) => relays.item[el].write).map((r,i,a) => 
           <div className="card flex">
             <div className="flex f-col f-grow">
-              <div>
-                <FormattedMessage defaultMessage="{relay}" values={{ relay:r }} />
-              </div>
+              <div>{r}</div>
             </div>
             <div>
               <input

--- a/packages/app/src/Element/ReBroadcaster.tsx
+++ b/packages/app/src/Element/ReBroadcaster.tsx
@@ -1,0 +1,85 @@
+import { FormattedMessage } from "react-intl";
+import { useDispatch, useSelector } from "react-redux";
+import useEventPublisher from "Feed/EventPublisher";
+import Modal from "Element/Modal";
+import type { RootState } from "State/Store";
+import { setShow, reset, setSelectedCustomRelays } from "State/ReBroadcast";
+import messages from "./messages";
+import useLogin from "Hooks/useLogin";
+
+export function ReBroadcaster() {
+  const publisher = useEventPublisher();
+  const { note, show, selectedCustomRelays } =
+    useSelector((s: RootState) => s.reBroadcast);
+  const dispatch = useDispatch();
+
+  async function sendReBroadcast() {
+    if (note && publisher) {
+      if (selectedCustomRelays) publisher.broadcastAll(note,selectedCustomRelays);
+      else publisher.broadcast(note);
+      dispatch(reset());
+    }
+  }
+
+  function cancel() {
+    dispatch(reset());
+  }
+
+  function onSubmit(ev: React.MouseEvent<HTMLButtonElement>) {
+    ev.stopPropagation();
+    sendReBroadcast().catch(console.warn);
+  }
+
+  const login = useLogin();
+  const relays = login.relays;
+
+  function renderRelayCustomisation() {
+    return (
+      <div>
+        {Object.keys(relays.item || {}).filter((el) => relays.item[el].write).map((r,i,a) => 
+          <div className="card flex">
+            <div className="flex f-col f-grow">
+              <div>
+                <FormattedMessage defaultMessage="{relay}" values={{ relay:r }} />
+              </div>
+            </div>
+            <div>
+              <input
+                type="checkbox"
+                checked={!selectedCustomRelays || selectedCustomRelays.includes(r)}
+                onChange={e => dispatch(setSelectedCustomRelays(
+                  // set false if all relays selected
+                  e.target.checked && selectedCustomRelays && selectedCustomRelays.length == a.length - 1
+                    ? false
+                  // otherwise return selectedCustomRelays with target relay added / removed 
+                    : a.filter((el) => el === r
+                    ? e.target.checked
+                    : !selectedCustomRelays || selectedCustomRelays.includes(el)
+                  )
+                ))}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {show && (
+        <Modal className="note-creator-modal" onClose={() => dispatch(setShow(false))}>
+          {renderRelayCustomisation()}
+          <div className="note-creator-actions">
+            <button className="secondary" onClick={cancel}>
+              <FormattedMessage {...messages.Cancel} />
+            </button>
+            <button onClick={onSubmit}>
+              <FormattedMessage {...messages.ReBroadcast} />
+            </button>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/packages/app/src/Element/ReBroadcaster.tsx
+++ b/packages/app/src/Element/ReBroadcaster.tsx
@@ -9,13 +9,12 @@ import useLogin from "Hooks/useLogin";
 
 export function ReBroadcaster() {
   const publisher = useEventPublisher();
-  const { note, show, selectedCustomRelays } =
-    useSelector((s: RootState) => s.reBroadcast);
+  const { note, show, selectedCustomRelays } = useSelector((s: RootState) => s.reBroadcast);
   const dispatch = useDispatch();
 
   async function sendReBroadcast() {
     if (note && publisher) {
-      if (selectedCustomRelays) publisher.broadcastAll(note,selectedCustomRelays);
+      if (selectedCustomRelays) publisher.broadcastAll(note, selectedCustomRelays);
       else publisher.broadcast(note);
       dispatch(reset());
     }
@@ -36,29 +35,34 @@ export function ReBroadcaster() {
   function renderRelayCustomisation() {
     return (
       <div>
-        {Object.keys(relays.item || {}).filter((el) => relays.item[el].write).map((r,i,a) => 
-          <div className="card flex">
-            <div className="flex f-col f-grow">
-              <div>{r}</div>
+        {Object.keys(relays.item || {})
+          .filter(el => relays.item[el].write)
+          .map((r, i, a) => (
+            <div className="card flex">
+              <div className="flex f-col f-grow">
+                <div>{r}</div>
+              </div>
+              <div>
+                <input
+                  type="checkbox"
+                  checked={!selectedCustomRelays || selectedCustomRelays.includes(r)}
+                  onChange={e =>
+                    dispatch(
+                      setSelectedCustomRelays(
+                        // set false if all relays selected
+                        e.target.checked && selectedCustomRelays && selectedCustomRelays.length == a.length - 1
+                          ? false
+                          : // otherwise return selectedCustomRelays with target relay added / removed
+                            a.filter(el =>
+                              el === r ? e.target.checked : !selectedCustomRelays || selectedCustomRelays.includes(el)
+                            )
+                      )
+                    )
+                  }
+                />
+              </div>
             </div>
-            <div>
-              <input
-                type="checkbox"
-                checked={!selectedCustomRelays || selectedCustomRelays.includes(r)}
-                onChange={e => dispatch(setSelectedCustomRelays(
-                  // set false if all relays selected
-                  e.target.checked && selectedCustomRelays && selectedCustomRelays.length == a.length - 1
-                    ? false
-                  // otherwise return selectedCustomRelays with target relay added / removed 
-                    : a.filter((el) => el === r
-                    ? e.target.checked
-                    : !selectedCustomRelays || selectedCustomRelays.includes(el)
-                  )
-                ))}
-              />
-            </div>
-          </div>
-        )}
+          ))}
       </div>
     );
   }

--- a/packages/app/src/Element/messages.ts
+++ b/packages/app/src/Element/messages.ts
@@ -104,4 +104,5 @@ export default defineMessages({
   ConfirmUnbookmark: { defaultMessage: "Are you sure you want to remove this note from bookmarks?" },
   ConfirmUnpin: { defaultMessage: "Are you sure you want to unpin this note?" },
   ReactionsLink: { defaultMessage: "{n} Reactions" },
+  ReBroadcast: { defaultMessage: "Broadcast Again" },
 });

--- a/packages/app/src/State/NoteCreator.ts
+++ b/packages/app/src/State/NoteCreator.ts
@@ -9,6 +9,7 @@ interface NoteCreatorStore {
   preview?: RawEvent;
   replyTo?: TaggedRawEvent;
   showAdvanced: boolean;
+  selectedCustomRelays: false | Array<string>;
   zapForward: string;
   sensitive: string;
   pollOptions?: Array<string>;
@@ -21,6 +22,7 @@ const InitState: NoteCreatorStore = {
   error: "",
   active: false,
   showAdvanced: false,
+  selectedCustomRelays: false,
   zapForward: "",
   sensitive: "",
   otherEvents: [],
@@ -51,6 +53,9 @@ const NoteCreatorSlice = createSlice({
     setShowAdvanced: (state, action: PayloadAction<boolean>) => {
       state.showAdvanced = action.payload;
     },
+    setSelectedCustomRelays: (state, action: PayloadAction<false | Array<string>>) => {
+      state.selectedCustomRelays = action.payload;
+    },
     setZapForward: (state, action: PayloadAction<string>) => {
       state.zapForward = action.payload;
     },
@@ -75,6 +80,7 @@ export const {
   setPreview,
   setReplyTo,
   setShowAdvanced,
+  setSelectedCustomRelays,
   setZapForward,
   setSensitive,
   setPollOptions,

--- a/packages/app/src/State/ReBroadcast.ts
+++ b/packages/app/src/State/ReBroadcast.ts
@@ -29,11 +29,6 @@ const ReBroadcastSlice = createSlice({
   },
 });
 
-export const {
-  setShow,
-  setNote,
-  setSelectedCustomRelays,
-  reset,
-} = ReBroadcastSlice.actions;
+export const { setShow, setNote, setSelectedCustomRelays, reset } = ReBroadcastSlice.actions;
 
 export const reducer = ReBroadcastSlice.reducer;

--- a/packages/app/src/State/ReBroadcast.ts
+++ b/packages/app/src/State/ReBroadcast.ts
@@ -1,0 +1,39 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { RawEvent } from "@snort/nostr";
+
+interface ReBroadcastStore {
+  show: boolean;
+  selectedCustomRelays: false | Array<string>;
+  note?: RawEvent;
+}
+
+const InitState: ReBroadcastStore = {
+  show: false,
+  selectedCustomRelays: false,
+};
+
+const ReBroadcastSlice = createSlice({
+  name: "ReBroadcast",
+  initialState: InitState,
+  reducers: {
+    setShow: (state, action: PayloadAction<boolean>) => {
+      state.show = action.payload;
+    },
+    setNote: (state, action: PayloadAction<RawEvent>) => {
+      state.note = action.payload;
+    },
+    setSelectedCustomRelays: (state, action: PayloadAction<false | Array<string>>) => {
+      state.selectedCustomRelays = action.payload;
+    },
+    reset: () => InitState,
+  },
+});
+
+export const {
+  setShow,
+  setNote,
+  setSelectedCustomRelays,
+  reset,
+} = ReBroadcastSlice.actions;
+
+export const reducer = ReBroadcastSlice.reducer;

--- a/packages/app/src/State/Store.ts
+++ b/packages/app/src/State/Store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { reducer as NoteCreatorReducer } from "State/NoteCreator";
+import { reducer as ReBroadcastReducer } from "State/ReBroadcast";
 
 const store = configureStore({
   reducer: {
     noteCreator: NoteCreatorReducer,
+    reBroadcast: ReBroadcastReducer,
   },
 });
 


### PR DESCRIPTION
The rationale for this feature is that users should have greater control over which relays they publish to on a case by case basis. They should also be able to change their mind (hence the rebroadcast feature).

Implementation: This adds two related features to different sections of the UI:

### 1. broadcast note to specific relays

Added a new section to the advanced options in NoteCreator which is used for both new notes and replies. This lists the users write relays and enables users to uncheck relays they do not wish to broadcast the note to.
When one or more relays are unchecked the submission is diverted from ```publisher.broadcast``` to ```publisher.broadcastAll``` with the desired relays specified.

![image](https://user-images.githubusercontent.com/114834599/233389367-beee13de-5add-4b9a-96fa-de05085a3cc7.png)

### 2. rebroadcast user's own note to specific relays

Replaces 'block' from the 'more' menu on a given note with 'Broadcast Again' if the note was authored by the logged in user. The logic here is that the user won't want to block themselves. We also don't think they should be broadcasting other people's notes to new relays. When the new option is selected a modal opens where the user can uncheck the relays they do not want to (re)broadcast to. 

![image](https://user-images.githubusercontent.com/114834599/233396770-cd1937b2-85a3-4472-9b3c-22c1ed7691f6.png)
