### PR TITLE
fix text overflow on follow button

### DIFF
--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -601,6 +601,10 @@ button.tall {
   justify-content: space-between;
 }
 
+.action-heading button {
+  min-width: 98px;
+}
+
 .flex-end {
   display: flex;
   justify-content: flex-end;

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -601,10 +601,6 @@ button.tall {
   justify-content: space-between;
 }
 
-.action-heading button {
-  width: 98px;
-}
-
 .flex-end {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
In some languages and resolutions, the text 'Follow' for hashtags is overflowing.

![image](https://user-images.githubusercontent.com/2035886/233762411-56eb7fbd-55f8-4d07-8ba4-d3ae7116ec7c.png)

This is due to the fixed width of the button.

This PR fixes it.

Screenshot after fix:

![image](https://user-images.githubusercontent.com/2035886/233762434-f61eaac1-8c40-43af-8a50-969975c1ffda.png)
