### PR TITLE
fix url regex

### DIFF
--- a/packages/app/src/Util.ts
+++ b/packages/app/src/Util.ts
@@ -303,7 +303,7 @@ export function groupByPubkey(acc: Record<HexKey, MetadataCache>, user: Metadata
 
 export function splitByUrl(str: string) {
   const urlRegex =
-    /((?:http|ftp|https|nostr|web\+nostr|magnet):\/?\/?(?:[\w+?.\w+])+(?:[a-zA-Z0-9~!@#$%^&*()_\-=+\\/?.:;',]*)?(?:[-A-Za-z0-9+&@#/%=~_|]))/i;
+    /((?:http|ftp|https|nostr|web\+nostr|magnet):\/?\/?(?:[\w+?.\w+])+(?:[a-zA-Z0-9~!@#$%^&*()_\-=+\\/?.:;',]*)?(?:[-A-Za-z0-9+&@#/%=~()_|]))/i;
 
   return str.split(urlRegex);
 }


### PR DESCRIPTION
For example:
`https://en.wikipedia.org/wiki/Git_(slang)`
[`https://en.wikipedia.org/wiki/Git_(slang)`](https://en.wikipedia.org/wiki/Git_(slang))

snort will match `https://en.wikipedia.org/wiki/Git_(slang`