### PR TITLE
Fix relay list

### DIFF
--- a/packages/app/src/System/EventPublisher.ts
+++ b/packages/app/src/System/EventPublisher.ts
@@ -283,7 +283,9 @@ export class EventPublisher {
       if (rx.settings.write && !rx.settings.read) {
         rTag.push("write");
       }
-      eb.tag(rTag);
+      if (rx.settings.read || rx.settings.write) {
+        eb.tag(rTag);
+      }
     }
     return await this.#sign(eb);
   }


### PR DESCRIPTION
`r` tag without second parameter (which means `read: true, write: true`) is added to kind 10002 when `read: false, write: false`.