### PR TITLE
add missing install command on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This repository is a yarn workspace. To install dependencies, run `yarn` from th
 To run the application, use
 
 ```
+$ yarn install
 $ yarn start
 ```
 


### PR DESCRIPTION
Wouldn't run unless I did a `yarn install` before running the app. Might be wrong, first time using yarn.