### PR TITLE
feat(unprivileged): run unprivileged nginx for security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
 FROM node:16 as build
 WORKDIR /app
 
-COPY package.json yarn.lock .
-COPY packages/app/package.json packages/app/
-COPY packages/nostr/package.json packages/nostr/
-RUN yarn install --network-timeout 1000000
-
 COPY . .
+RUN yarn install --network-timeout 1000000
 RUN yarn build
 
-FROM nginx:mainline-alpine
+FROM nginxinc/nginx-unprivileged:mainline-alpine
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/packages/app/build /usr/share/nginx/html


### PR DESCRIPTION
- fix docker build errors, verified with `docker buildx build -t snort --platform linux/amd64 .`
- use non-root nginx base image[^1] for container security

[^1]: https://github.com/nginxinc/docker-nginx-unprivileged