### PR TITLE
fix: avatar z-index incorrect

### DIFF
--- a/packages/app/src/Element/User/ProfileImage.css
+++ b/packages/app/src/Element/User/ProfileImage.css
@@ -13,7 +13,6 @@
   height: 48px;
   cursor: pointer;
   position: relative;
-  z-index: 2;
 }
 
 a.pfp {


### PR DESCRIPTION
Fix avatar z-index incorrect.

<img width="808" alt="image" src="https://github.com/v0l/snort/assets/7018802/05f94a79-a98f-4577-a7a8-debcacbd1783">

After fixed:

<img width="835" alt="image" src="https://github.com/v0l/snort/assets/7018802/00eec178-8314-4bea-8e29-0b5363a6cbcd">

