### PR TITLE
don't close publish modal automatically

### DIFF
--- a/packages/app/src/Element/Event/NoteBroadcaster.tsx
+++ b/packages/app/src/Element/Event/NoteBroadcaster.tsx
@@ -42,15 +42,8 @@ export function NoteBroadcaster({
     }
   }
 
-  async function sendNote() {
-    const results = await Promise.all(evs.map(a => sendEventToRelays(a)).flat());
-    if (results.flat().every(a => a.ok)) {
-      onClose();
-    }
-  }
-
   useEffect(() => {
-    sendNote().catch(console.error);
+    Promise.all(evs.map(a => sendEventToRelays(a)).flat()).catch(console.error);
   }, []);
 
   async function removeRelayFromResult(r: OkResponse) {


### PR DESCRIPTION
currently if one of the target relays fail you get a nice modal with a list of all successes and failures, but if all relays succeed your screen blinks with an unreadable modal and you don't know to where the note was published.

with this even if all relays responded with an OK the modal will still remain open so the user can look at the list of relays the note was published to.
