### PR TITLE
add `trailingComma` to prettier settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "prettier": {
     "printWidth": 120,
     "bracketSameLine": true,
-    "arrowParens": "avoid"
+    "arrowParens": "avoid",
+    "trailingComma": "all"
   },
   "packageManager": "yarn@3.6.3",
   "dependencies": {


### PR DESCRIPTION
because my system was still using the old defaults and that was bad.