### PR TITLE
Trim Zap comment

### DIFF
--- a/packages/system/src/event-publisher.ts
+++ b/packages/system/src/event-publisher.ts
@@ -179,7 +179,7 @@ export class EventPublisher {
     fnExtra?: EventBuilderHook,
   ) {
     const eb = this.#eb(EventKind.ZapRequest);
-    eb.content(msg ?? "");
+    eb.content(msg?.trim() ?? "");
     if (note) {
       // HACK: remove relay tag, some zap services dont like relay tags
       eb.tag(unwrap(note.toEventTag()).slice(0, 2));


### PR DESCRIPTION
We had a bug when trying to parse the json of a comment. It had a \n at the end of it and a browser's json parser couldn't handle it. This should fix