### PR TITLE
Show border when there is no selected DM

### DIFF
--- a/packages/app/src/Pages/Messages/MessagesPage.tsx
+++ b/packages/app/src/Pages/Messages/MessagesPage.tsx
@@ -109,7 +109,7 @@ export default function MessagesPage() {
             .map(conversation)}
         </div>
       )}
-      {chat ? <DmWindow id={chat} /> : pageWidth >= TwoCol && <div className="flex-1"></div>}
+      {chat ? <DmWindow id={chat} /> : pageWidth >= TwoCol && <div className="flex-1 rt-border"></div>}
     </div>
   );
 }

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -932,6 +932,6 @@ svg.zap-solid {
 @media (min-width: 768px) {
   .rt-border{
     border-right-width: 1px;
-    border-right-color: red;
+    border-right-color: var(--border-color);
   }
 }

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -928,3 +928,10 @@ svg.zap-solid {
 .hide-scrollbar::-webkit-scrollbar {
   display: none; /* Safari and Chrome */
 }
+
+@media (min-width: 768px) {
+  .rt-border{
+    border-right-width: 1px;
+    border-right-color: red;
+  }
+}


### PR DESCRIPTION
Fixes https://git.v0l.io/Kieran/snort/issues/710

* Shows red border as suggested when there is no selected DM and is visible only on  large screens