### PR TITLE
change settings message when choosing a username

### DIFF
--- a/packages/app/src/Element/messages.ts
+++ b/packages/app/src/Element/messages.ts
@@ -99,7 +99,7 @@ export default defineMessages({
   ConfirmUnpin: { defaultMessage: "Are you sure you want to unpin this note?", id: "IEwZvs" },
   ReactionsLink: { defaultMessage: "{n} Reactions", id: "jzgQ2z" },
   ReBroadcast: { defaultMessage: "Broadcast Again", id: "c3g2hL" },
-  IrisUserNameLengthError: { defaultMessage: "Name must be between 1 and 32 characters", id: "4MBtMa" },
+  IrisUserNameLengthError: { defaultMessage: "Name must be between 8 and 15 characters", id: "4MBtMa" },
   IrisUserNameFormatError: { defaultMessage: "Username must only contain lowercase letters and numbers", id: "RSr2uB" },
   InvalidNip05Address: { defaultMessage: "Invalid Nostr Address", id: "P2o+ZZ" },
   ErrorValidatingNip05Address: { defaultMessage: "Cannot verify Nostr Address", id: "LmdPXO" },


### PR DESCRIPTION
It says the username must be between 1 and 32 characters. It should be 8 and 15. Iris will only accept it with that character length.


<img width="1284" alt="Screen Shot 2024-01-01 at 4 53 57 PM" src="https://github.com/v0l/snort/assets/97064249/66d76bd0-2a09-4e93-906b-f0dcf59392a0">

