### PR TITLE
[TIDAL Embeds] Add allow and sandbox attributes

### DIFF
--- a/packages/app/src/Components/Embed/TidalEmbed.tsx
+++ b/packages/app/src/Components/Embed/TidalEmbed.tsx
@@ -55,7 +55,7 @@ const TidalEmbed = ({ link }: { link: string }) => {
   }
   const iframe = (
     // eslint-disable-next-line react/no-unknown-property
-    <iframe src={source} style={extraStyles} width="100%" title="TIDAL Embed" frameBorder={0} credentialless="" />
+    <iframe src={source} style={extraStyles} width="100%" allow="encrypted-media *; clipboard-write *; clipboard-read *" sandbox="allow-scripts allow-popups allow-forms allow-same-origin"  title="TIDAL Embed" frameBorder={0} credentialless="" />
   );
   return (
     <>


### PR DESCRIPTION
Playback won't work correctly without the `allow="encrypted-media"` attribute. Also added the sandbox attribute to improve security.