### PR TITLE
[worker-relay] Decouple worker functions from worker

### DIFF
--- a/packages/worker-relay/example/basic.ts
+++ b/packages/worker-relay/example/basic.ts
@@ -1,7 +1,7 @@
-import { WorkerRelayInterface } from "@snort/worker-relay";
+import { WorkerRelayInterface } from "@nostrwatch/worker-relay";
 
 // when using Vite import the worker script directly (for production)
-import WorkerVite from "@snort/worker-relay/src/worker?worker";
+import WorkerVite from "@nostrwatch/worker-relay/src/worker?worker";
 
 // in dev mode import esm module, i have no idea why it has to work like this
 const workerScript = import.meta.env.DEV

--- a/packages/worker-relay/example/basic.ts
+++ b/packages/worker-relay/example/basic.ts
@@ -1,7 +1,7 @@
-import { WorkerRelayInterface } from "@nostrwatch/worker-relay";
+import { WorkerRelayInterface } from "@snort/worker-relay";
 
 // when using Vite import the worker script directly (for production)
-import WorkerVite from "@nostrwatch/worker-relay/src/worker?worker";
+import WorkerVite from "@snort/worker-relay/src/worker?worker";
 
 // in dev mode import esm module, i have no idea why it has to work like this
 const workerScript = import.meta.env.DEV

--- a/packages/worker-relay/package.json
+++ b/packages/worker-relay/package.json
@@ -10,8 +10,9 @@
   "author": "Kieran",
   "license": "MIT",
   "scripts": {
-    "build": "rm -rf dist && tsc && yarn build:esm",
-    "build:esm": "esbuild src/worker.ts --bundle --minify --sourcemap --outdir=dist/esm --format=esm --out-extension:.js=.mjs --loader:.wasm=copy"
+    "build": "rm -rf dist && tsc && yarn copy:wasm && yarn build:esm",
+    "build:esm": "esbuild src/worker.ts --bundle --minify --sourcemap --outdir=dist/esm --format=esm --out-extension:.js=.mjs --loader:.wasm=copy",
+    "copy:wasm": "cp src/sqlite/sqlite3.wasm dist/sqlite/sqlite3.wasm"
   },
   "files": [
     "src",

--- a/packages/worker-relay/src/types.ts
+++ b/packages/worker-relay/src/types.ts
@@ -101,13 +101,20 @@ export function eventMatchesFilter(ev: NostrEvent, filter: ReqFilter) {
   if (!(filter.kinds?.includes(ev.kind) ?? true)) {
     return false;
   }
-  const tags = Object.entries(filter).filter(([k]) => k.startsWith("#"));
-  for (const [k, v] of tags) {
+  const orTags = Object.entries(filter).filter(([k]) => k.startsWith("#"));
+  for (const [k, v] of orTags) {
     const vargs = v as Array<string>;
     for (const x of vargs) {
       if (!ev.tags.find(a => a[0] === k.slice(1) && a[1] === x)) {
         return false;
       }
+    }
+  }
+  const andTags = Object.entries(filter).filter(([k]) => k.startsWith("&"));
+  for (const [k, v] of andTags) {
+    const allMatch = (v as string[]).every(x => ev.tags.some(tag => tag[0] === k.slice(1) && tag[1] === x));
+    if (!allMatch) {
+      return false;
     }
   }
 

--- a/packages/worker-relay/src/types.ts
+++ b/packages/worker-relay/src/types.ts
@@ -101,21 +101,13 @@ export function eventMatchesFilter(ev: NostrEvent, filter: ReqFilter) {
   if (!(filter.kinds?.includes(ev.kind) ?? true)) {
     return false;
   }
-  const orTags = Object.entries(filter).filter(([k]) => k.startsWith("#"));
-  for (const [k, v] of orTags) {
+  const tags = Object.entries(filter).filter(([k]) => k.startsWith("#"));
+  for (const [k, v] of tags) {
     const vargs = v as Array<string>;
     for (const x of vargs) {
       if (!ev.tags.find(a => a[0] === k.slice(1) && a[1] === x)) {
         return false;
       }
-    }
-  }
-  const andTags = Object.entries(filter).filter(([k]) => k.startsWith("&"));
-  for (const [k, v] of andTags) {
-    const vargs = v as Array<string>;
-    const allMatch = vargs.every(x => ev.tags.some(tag => tag[0] === k.slice(1) && tag[1] === x));
-    if (!allMatch) {
-      return false;
     }
   }
 

--- a/packages/worker-relay/src/types.ts
+++ b/packages/worker-relay/src/types.ts
@@ -112,7 +112,8 @@ export function eventMatchesFilter(ev: NostrEvent, filter: ReqFilter) {
   }
   const andTags = Object.entries(filter).filter(([k]) => k.startsWith("&"));
   for (const [k, v] of andTags) {
-    const allMatch = (v as string[]).every(x => ev.tags.some(tag => tag[0] === k.slice(1) && tag[1] === x));
+    const vargs = v as Array<string>;
+    const allMatch = vargs.every(x => ev.tags.some(tag => tag[0] === k.slice(1) && tag[1] === x));
     if (!allMatch) {
       return false;
     }

--- a/packages/worker-relay/src/worker-utils.ts
+++ b/packages/worker-relay/src/worker-utils.ts
@@ -1,0 +1,176 @@
+import { SqliteRelay } from "./sqlite/sqlite-relay";
+import { InMemoryRelay } from "./memory-relay";
+import { setLogging } from "./debug";
+
+import {
+    NostrEvent,
+    ReqCommand,
+    ReqFilter,
+    WorkerMessage,
+    unixNowMs,
+    EventMetadata,
+    OkResponse,
+    RelayHandler,
+  } from "./types";
+
+import { getForYouFeed } from "forYouFeed";
+
+export interface InitAargs {
+  databasePath: string;
+  insertBatchSize?: number;
+}
+
+export interface WorkerState {
+  relay: RelayHandler | undefined;
+  insertBatchSize: number;
+  eventWriteQueue: Array<NostrEvent>;
+}
+
+export async function insertBatch(state: WorkerState) {
+  if (state.eventWriteQueue.length > 0) {
+    const start = unixNowMs();
+    const timeLimit = 1000;
+    if (state.relay) {
+      while (state.eventWriteQueue.length > 0) {
+        if (unixNowMs() - start >= timeLimit) {
+          break;
+        }
+        const batch = state.eventWriteQueue.splice(0, state.insertBatchSize);
+        state.eventWriteQueue = state.eventWriteQueue.slice(batch.length);
+        state.relay.eventBatch(batch);
+      }
+    }
+  }
+  setTimeout(() => insertBatch(state), 100);
+}
+
+export const handleMsg = async (state: WorkerState, port: MessagePort | DedicatedWorkerGlobalScope, ev: MessageEvent) => {
+  async function reply<T>(id: string, obj?: T) {
+    port.postMessage({
+      id,
+      cmd: "reply",
+      args: obj,
+    } as WorkerMessage<T>);
+  }
+
+  const msg = ev.data as WorkerMessage<any>;
+  try {
+    switch (msg.cmd) {
+      case "debug": {
+        setLogging(true);
+        reply(msg.id, true);
+        break;
+      }
+      case "init": {
+        const args = msg.args as InitAargs;
+        state.insertBatchSize = args.insertBatchSize ?? 10;
+        try {
+          if ("WebAssembly" in self) {
+            state.relay = new SqliteRelay();
+          } else {
+            state.relay = new InMemoryRelay();
+          }
+          await state.relay.init(args.databasePath);
+        } catch (e) {
+          console.error("Fallback to InMemoryRelay", e);
+          state.relay = new InMemoryRelay();
+          await state.relay.init(args.databasePath);
+        }
+        reply(msg.id, true);
+        break;
+      }
+      case "event": {
+        const ev = msg.args as NostrEvent;
+        state.eventWriteQueue.push(ev);
+        reply(msg.id, {
+          ok: true,
+          id: ev.id,
+          relay: "",
+        } as OkResponse);
+        break;
+      }
+      case "close": {
+        const res = state.relay!.close();
+        reply(msg.id, res);
+        break;
+      }
+      case "req": {
+        const req = msg.args as ReqCommand;
+        const filters = req.slice(2) as Array<ReqFilter>;
+        const results: Array<string | NostrEvent> = [];
+        const ids = new Set<string>();
+        for (const r of filters) {
+          const rx = state.relay!.req(req[1], r);
+          for (const x of rx) {
+            if ((typeof x === "string" && ids.has(x)) || ids.has((x as NostrEvent).id)) {
+              continue;
+            }
+            ids.add(typeof x === "string" ? x : (x as NostrEvent).id);
+            results.push(x);
+          }
+        }
+        reply(msg.id, results);
+        break;
+      }
+      case "count": {
+        const req = msg.args as ReqCommand;
+        let results = 0;
+        const filters = req.slice(2) as Array<ReqFilter>;
+        for (const r of filters) {
+          const c = state.relay!.count(r);
+          results += c;
+        }
+        reply(msg.id, results);
+        break;
+      }
+      case "delete": {
+        const req = msg.args as ReqCommand;
+        let results = [];
+        const filters = req.slice(2) as Array<ReqFilter>;
+        for (const r of filters) {
+          const c = state.relay!.delete(r);
+          results.push(...c);
+        }
+        reply(msg.id, results);
+        break;
+      }
+      case "summary": {
+        const res = state.relay!.summary();
+        reply(msg.id, res);
+        break;
+      }
+      case "dumpDb": {
+        const res = await state.relay!.dump();
+        reply(msg.id, res);
+        break;
+      }
+      case "wipe": {
+        await state.relay!.wipe();
+        reply(msg.id, true);
+        break;
+      }
+      case "forYouFeed": {
+        const res = await getForYouFeed(relay!, msg.args as string);
+        reply(msg.id, res);
+        break;
+      }
+      case "setEventMetadata": {
+        const [id, metadata] = msg.args as [string, EventMetadata];
+        state.relay!.setEventMetadata(id, metadata);
+        break;
+      }
+      default: {
+        reply(msg.id, { error: "Unknown command" });
+        break;
+      }
+    }
+  } catch (e) {
+    if (e instanceof Error) {
+      reply(msg.id, { error: e.message });
+    } else if (typeof e === "string") {
+      reply(msg.id, { error: e });
+    } else {
+      reply(msg.id, "Unknown error");
+    }
+  }
+};

--- a/packages/worker-relay/src/worker-utils.ts
+++ b/packages/worker-relay/src/worker-utils.ts
@@ -21,7 +21,7 @@ export interface InitAargs {
 }
 
 export interface WorkerState {
-  self: DedicatedWorkerGlobalScope;
+  self: DedicatedWorkerGlobalScope | SharedWorkerGlobalScope;
   relay: RelayHandler | undefined;
   insertBatchSize: number;
   eventWriteQueue: Array<NostrEvent>;
@@ -45,9 +45,10 @@ export async function insertBatch(state: WorkerState) {
   setTimeout(() => insertBatch(state), 100);
 }
 
-export const handleMsg = async (state: WorkerState, port: MessagePort | DedicatedWorkerGlobalScope, ev: MessageEvent) => {
+export const handleMsg = async (state: WorkerState, ev: MessageEvent, port?: MessagePort) => {
   async function reply<T>(id: string, obj?: T) {
-    port.postMessage({
+    const _port = (port ?? state.self) as MessagePort | DedicatedWorkerGlobalScope;
+    _port.postMessage({
       id,
       cmd: "reply",
       args: obj,

--- a/packages/worker-relay/src/worker-utils.ts
+++ b/packages/worker-relay/src/worker-utils.ts
@@ -150,7 +150,7 @@ export const handleMsg = async (state: WorkerState, port: MessagePort | Dedicate
         break;
       }
       case "forYouFeed": {
-        const res = await getForYouFeed(relay!, msg.args as string);
+        const res = await getForYouFeed(state.relay!, msg.args as string);
         reply(msg.id, res);
         break;
       }

--- a/packages/worker-relay/src/worker-utils.ts
+++ b/packages/worker-relay/src/worker-utils.ts
@@ -21,6 +21,7 @@ export interface InitAargs {
 }
 
 export interface WorkerState {
+  self: DedicatedWorkerGlobalScope;
   relay: RelayHandler | undefined;
   insertBatchSize: number;
   eventWriteQueue: Array<NostrEvent>;
@@ -65,7 +66,7 @@ export const handleMsg = async (state: WorkerState, port: MessagePort | Dedicate
         const args = msg.args as InitAargs;
         state.insertBatchSize = args.insertBatchSize ?? 10;
         try {
-          if ("WebAssembly" in self) {
+          if ("WebAssembly" in state.self) {
             state.relay = new SqliteRelay();
           } else {
             state.relay = new InMemoryRelay();

--- a/packages/worker-relay/src/worker.ts
+++ b/packages/worker-relay/src/worker.ts
@@ -3,7 +3,7 @@
 import { handleMsg, insertBatch, WorkerState } from "./worker-utils";
 
 const state: WorkerState = {
-  self: self as DedicatedWorkerGlobalScope,
+  self: self as DedicatedWorkerGlobalScope | SharedWorkerGlobalScope,
   relay: undefined,
   insertBatchSize: 10,
   eventWriteQueue: []
@@ -18,12 +18,12 @@ try {
 if ("SharedWorkerGlobalScope" in globalThis) {
   onconnect = e => {
     const port = e.ports[0];
-    port.onmessage = (msg: MessageEvent)  => handleMsg(state, port, msg);
+    port.onmessage = (msg: MessageEvent) => handleMsg(state, msg, port);
     port.start();
   };
 }
 if ("DedicatedWorkerGlobalScope" in globalThis) {
   onmessage = e => {
-    handleMsg(state, self as DedicatedWorkerGlobalScope, e);
+    handleMsg(state, e);
   };
 }

--- a/packages/worker-relay/src/worker.ts
+++ b/packages/worker-relay/src/worker.ts
@@ -3,6 +3,7 @@
 import { handleMsg, insertBatch, WorkerState } from "./worker-utils";
 
 const state: WorkerState = {
+  self: self as DedicatedWorkerGlobalScope,
   relay: undefined,
   insertBatchSize: 10,
   eventWriteQueue: []

--- a/packages/worker-relay/src/worker.ts
+++ b/packages/worker-relay/src/worker.ts
@@ -1,199 +1,28 @@
 /// <reference lib="webworker" />
 
-import { SqliteRelay } from "./sqlite/sqlite-relay";
-import { InMemoryRelay } from "./memory-relay";
-import { setLogging } from "./debug";
-import { WorkQueueItem, barrierQueue, processWorkQueue } from "./queue";
-import {
-  NostrEvent,
-  RelayHandler,
-  ReqCommand,
-  ReqFilter,
-  WorkerMessage,
-  unixNowMs,
-  EventMetadata,
-  OkResponse,
-} from "./types";
-import { getForYouFeed } from "./forYouFeed";
+import { handleMsg, insertBatch, WorkerState } from "./worker-utils";
 
-let relay: RelayHandler | undefined;
-let insertBatchSize = 10;
-
-// Event inserter queue
-let eventWriteQueue: Array<NostrEvent> = [];
-async function insertBatch() {
-  // Only insert event batches when the command queue is empty
-  // This is to make req's execute first and not block them
-  if (eventWriteQueue.length > 0) {
-    const start = unixNowMs();
-    const timeLimit = 1000;
-    if (relay) {
-      while (eventWriteQueue.length > 0) {
-        if (unixNowMs() - start >= timeLimit) {
-          //console.debug("Yield insert, queue length: ", eventWriteQueue.length, ", cmds: ", cmdQueue.length);
-          break;
-        }
-        const batch = eventWriteQueue.splice(0, insertBatchSize);
-        eventWriteQueue = eventWriteQueue.slice(batch.length);
-        relay.eventBatch(batch);
-      }
-    }
-  }
-  setTimeout(() => insertBatch(), 100);
+const state: WorkerState = {
+  relay: undefined,
+  insertBatchSize: 10,
+  eventWriteQueue: []
 }
 
-const cmdQueue: Array<WorkQueueItem> = [];
 try {
-  setTimeout(() => insertBatch(), 100);
+  setTimeout(() => insertBatch(state), 100);
 } catch (e) {
   console.error(e);
 }
 
-interface InitAargs {
-  databasePath: string;
-  insertBatchSize?: number;
-}
-
-const handleMsg = async (port: MessagePort | DedicatedWorkerGlobalScope, ev: MessageEvent) => {
-  async function reply<T>(id: string, obj?: T) {
-    port.postMessage({
-      id,
-      cmd: "reply",
-      args: obj,
-    } as WorkerMessage<T>);
-  }
-
-  const msg = ev.data as WorkerMessage<any>;
-  try {
-    switch (msg.cmd) {
-      case "debug": {
-        setLogging(true);
-        reply(msg.id, true);
-        break;
-      }
-      case "init": {
-        const args = msg.args as InitAargs;
-        insertBatchSize = args.insertBatchSize ?? 10;
-        try {
-          if ("WebAssembly" in self) {
-            relay = new SqliteRelay();
-          } else {
-            relay = new InMemoryRelay();
-          }
-          await relay.init(args.databasePath);
-        } catch (e) {
-          console.error("Fallback to InMemoryRelay", e);
-          relay = new InMemoryRelay();
-          await relay.init(args.databasePath);
-        }
-        reply(msg.id, true);
-        break;
-      }
-      case "event": {
-        const ev = msg.args as NostrEvent;
-        eventWriteQueue.push(ev);
-        reply(msg.id, {
-          ok: true,
-          id: ev.id,
-          relay: "",
-        } as OkResponse);
-        break;
-      }
-      case "close": {
-        const res = relay!.close();
-        reply(msg.id, res);
-        break;
-      }
-      case "req": {
-        const req = msg.args as ReqCommand;
-        const filters = req.slice(2) as Array<ReqFilter>;
-        const results: Array<string | NostrEvent> = [];
-        const ids = new Set<string>();
-        for (const r of filters) {
-          const rx = relay!.req(req[1], r);
-          for (const x of rx) {
-            if ((typeof x === "string" && ids.has(x)) || ids.has((x as NostrEvent).id)) {
-              continue;
-            }
-            ids.add(typeof x === "string" ? x : (x as NostrEvent).id);
-            results.push(x);
-          }
-        }
-        reply(msg.id, results);
-        break;
-      }
-      case "count": {
-        const req = msg.args as ReqCommand;
-        let results = 0;
-        const filters = req.slice(2) as Array<ReqFilter>;
-        for (const r of filters) {
-          const c = relay!.count(r);
-          results += c;
-        }
-        reply(msg.id, results);
-        break;
-      }
-      case "delete": {
-        const req = msg.args as ReqCommand;
-        let results = [];
-        const filters = req.slice(2) as Array<ReqFilter>;
-        for (const r of filters) {
-          const c = relay!.delete(r);
-          results.push(...c);
-        }
-        reply(msg.id, results);
-        break;
-      }
-      case "summary": {
-        const res = relay!.summary();
-        reply(msg.id, res);
-        break;
-      }
-      case "dumpDb": {
-        const res = await relay!.dump();
-        reply(msg.id, res);
-        break;
-      }
-      case "wipe": {
-        await relay!.wipe();
-        reply(msg.id, true);
-        break;
-      }
-      case "forYouFeed": {
-        const res = await getForYouFeed(relay!, msg.args as string);
-        reply(msg.id, res);
-        break;
-      }
-      case "setEventMetadata": {
-        const [id, metadata] = msg.args as [string, EventMetadata];
-        relay!.setEventMetadata(id, metadata);
-        break;
-      }
-      default: {
-        reply(msg.id, { error: "Unknown command" });
-        break;
-      }
-    }
-  } catch (e) {
-    if (e instanceof Error) {
-      reply(msg.id, { error: e.message });
-    } else if (typeof e === "string") {
-      reply(msg.id, { error: e });
-    } else {
-      reply(msg.id, "Unknown error");
-    }
-  }
-};
-
 if ("SharedWorkerGlobalScope" in globalThis) {
   onconnect = e => {
     const port = e.ports[0];
-    port.onmessage = msg => handleMsg(port, msg);
+    port.onmessage = (msg: MessageEvent)  => handleMsg(state, port, msg);
     port.start();
   };
 }
 if ("DedicatedWorkerGlobalScope" in globalThis) {
   onmessage = e => {
-    handleMsg(self as DedicatedWorkerGlobalScope, e);
+    handleMsg(state, self as DedicatedWorkerGlobalScope, e);
   };
 }

--- a/packages/worker-relay/src/worker.ts
+++ b/packages/worker-relay/src/worker.ts
@@ -16,7 +16,7 @@ try {
 }
 
 if ("SharedWorkerGlobalScope" in globalThis) {
-  onconnect = e => {
+  onconnect = (e: MessageEvent) => {
     const port = e.ports[0];
     port.onmessage = (msg: MessageEvent) => handleMsg(state, msg, port);
     port.start();


### PR DESCRIPTION
This decouples the worker logic, namely the batching and message handling (and also types) from the worker.

**Why?**

_tldr;_

Flexability. Enables usage of everything in this library except the included `WebWorker`, with minimal changes to the package and no difference in usage.

....

It makes this package more flexible. In my case, I when I add an event, I don't do so from the main thread. I add the event from another web worker over a `MessageChannel`. While _maybe_ this package should include message channel functionality in the `init` message, I feel like that might be out of scope, and it does open a can of worms. 

By decoupling the worker logic from the worker itself, I am able to import just the worker logic I need, implement it according to my needs, while retaining the usefulness of `WorkerRelayInterface` for the main thread. 

**Notable Changes**
- All worker state was moved to a `state` object (typed) so that changes to state could be made by reference.
- `wasm:copy` script in package.json that copies `wasm` to dist/sqlite
- exported all relay actions so that the relay could receive commands without mocking `MessageEvent`'s first. (note: less readable, less maintainable, less clean than it was previously, but way more versatile). Added around ~100 bytes to package.

**Notes**
- Will cleanup history and squash  if you decide you want this, accidentally included changes from my other PR 🤦 
- **MIGHT** cause issues in some situations when bundling, but at a glance, the `worker` should bundle correctly in for `es/iife` and `inline`

**Potential Improvements**
Expose via exports in package instead of dist traversal on import.

**Usage Changes**
None. (see disclaimer)

**Disclaimer**
100% untested, hence the draft. I've made these same changes in the fork I'm maintaining so will likely patch and confirm functionality later.

