### PR TITLE
fix(chat): deliver NIP-17 DMs in real-time without conversation re-open

### DIFF
--- a/packages/app/src/chat/nip17.ts
+++ b/packages/app/src/chat/nip17.ts
@@ -43,7 +43,7 @@ export class Nip17ChatSystem extends ExternalStore<Array<Chat>> implements ChatS
     const rb = new RequestBuilder(`nip17:${pk?.slice(0, 12)}`)
 
     if (pk && !session.readonly) {
-      rb.withOptions({ useSyncModule: true })
+      rb.withOptions({ useSyncModule: true, leaveOpen: true })
       rb.withFilter().kinds([EventKind.GiftWrap]).tag("p", [pk])
     }
     return rb


### PR DESCRIPTION
## Summary

NIP-17 DMs don't stream live — new gift wraps only render after the user navigates away from the chat and back.

`Nip17ChatSystem.buildSub()` passes `useSyncModule: true` (enables negentropy) but omits `leaveOpen`, so the kind:1059 REQ closes as soon as backfill finishes. No live subscription remains for new wraps.

Pass `leaveOpen: true` alongside `useSyncModule: true` on the gift-wrap `RequestBuilder`. Negentropy still runs at startup; the REQ then stays subscribed.

## Related

- [NIP-17 — Private Direct Messages](https://github.com/nostr-protocol/nips/blob/master/17.md)
- [NIP-59 — Gift Wrap](https://github.com/nostr-protocol/nips/blob/master/59.md)
