### PR TITLE
fix(chat): preserve NIP-17 rumor created_at when unsealing gift wraps

### DIFF
--- a/packages/app/src/Cache/GiftWrapCache.ts
+++ b/packages/app/src/Cache/GiftWrapCache.ts
@@ -11,6 +11,12 @@ export interface UnwrappedGift {
   created_at: number
   inner: NostrEvent
   tags?: Array<Array<string>>
+  // NIP-59 randomises both the gift wrap and the seal's `created_at` by up
+  // to 48h in the past for metadata-leak resistance. Only the innermost
+  // rumor (kind 14) carries the true send time. We capture it here so the
+  // UI can sort and render messages chronologically; `inner` is left as
+  // the seal so the `EventKind.SealedRumor` check below keeps working.
+  rumorCreatedAt?: number
 }
 
 const DecryptedContentCache = new Map<string, string>()
@@ -94,6 +100,7 @@ export class GiftWrapCache extends RefreshFeedCache<UnwrappedGift> {
           }
           const unsealed = await pub.unsealRumor(u.inner)
           u.tags = unsealed.tags
+          u.rumorCreatedAt = unsealed.created_at
         } catch (e) {
           console.debug("Failed to unseal rumor", u.id, e)
           failed.add(i)

--- a/packages/app/src/chat/nip17.ts
+++ b/packages/app/src/chat/nip17.ts
@@ -92,12 +92,19 @@ export class Nip17ChatSystem extends ExternalStore<Array<Chat>> implements ChatS
     let lastMessage = 0
     for (const v of messages) {
       const sbj = v.tags?.find(a => a[0] === "subject")?.[1]
-      if (v.created_at > bestTitleTime && sbj) {
+      // Use the innermost rumor's created_at (true send time). NIP-59
+      // randomises BOTH the gift wrap (v.created_at) and the seal
+      // (v.inner.created_at) by up to 48h in the past for metadata-leak
+      // resistance. Only v.rumorCreatedAt (captured by GiftWrapCache after
+      // unsealing) carries the true send time. Fall back to the seal time
+      // for any cached entries from before this field was added.
+      const ts = v.rumorCreatedAt ?? v.inner.created_at
+      if (ts > bestTitleTime && sbj) {
         bestTitle = sbj
-        bestTitleTime = v.created_at
+        bestTitleTime = ts
       }
-      if (v.inner.created_at > last) unread++
-      if (v.created_at > lastMessage) lastMessage = v.created_at
+      if (ts > last) unread++
+      if (ts > lastMessage) lastMessage = ts
     }
     return {
       type: ChatType.PrivateDirectMessage,
@@ -110,7 +117,7 @@ export class Nip17ChatSystem extends ExternalStore<Array<Chat>> implements ChatS
         const cached = getCachedDecryptedContent(m.id)
         return {
           id: m.id,
-          created_at: m.inner.created_at,
+          created_at: m.rumorCreatedAt ?? m.inner.created_at,
           from: m.inner.pubkey,
           tags: m.tags,
           content: cached ?? "",
@@ -150,7 +157,7 @@ export class Nip17ChatSystem extends ExternalStore<Array<Chat>> implements ChatS
       },
       markRead: (msgId?: string) => {
         const msg = messages.find(a => a.id === msgId)
-        setLastReadIn(id, msg?.inner.created_at)
+        setLastReadIn(id, msg?.rumorCreatedAt ?? msg?.inner.created_at)
         Nip17Chats.notifyChange()
       },
     } as Chat


### PR DESCRIPTION
## Summary

NIP-17 threads display messages in the wrong order, place messages under the wrong date header, and report incorrect unread counts. Per [NIP-59 §3](https://github.com/nostr-protocol/nips/blob/master/59.md#3-timestamp-tweak), the gift wrap (kind:1059) and seal (kind:13) `created_at` are randomly backdated up to 48h; only the rumor (kind:14) carries the true send time.

`GiftWrapCache.onEvent` preserves `unsealed.tags` but discards `unsealed.created_at`, so every consumer in `chat/nip17.ts` ends up sorting/comparing on the backdated seal time.

## Changes

- `UnwrappedGift` gains optional `rumorCreatedAt?: number`
- `GiftWrapCache.onEvent` populates it from `unsealed.created_at`
- 6 sort/timestamp sites in `chat/nip17.ts` switched to `rumorCreatedAt ?? inner.created_at`:

| Site | Used for |
|---|---|
| `bestTitleTime` | thread list ordering |
| unread count comparison | `v.inner.created_at > last` |
| `lastMessage` selection | sidebar preview |
| `Message.created_at` | rendered bubble timestamp + date header |
| `markRead` advance target | read marker |
| `chats()` reducer sort key | message list order |

`UnwrappedGift.inner` stays as the seal so the existing `EventKind.SealedRumor` branch in `GiftWrapCache` keeps working. `RefreshFeedCache.newest()` continues to use the wrap `created_at` for the `since` filter — correct, that's about skipping seen wraps, not rumors. The `??` fallback means cache entries from before this PR keep working; no migration.

## Related

- [NIP-59 §3 — Timestamp Tweak](https://github.com/nostr-protocol/nips/blob/master/59.md#3-timestamp-tweak)
- [NIP-17 — Private Direct Messages](https://github.com/nostr-protocol/nips/blob/master/17.md)
