### PR TITLE
fix(chat): don't render literal "<ERROR>" when NIP-17 DM decrypt fails

### DIFF
--- a/packages/app/src/Pages/Messages/DM.tsx
+++ b/packages/app/src/Pages/Messages/DM.tsx
@@ -20,6 +20,7 @@ export default function DM(props: DMProps) {
   const { publisher } = useEventPublisher()
   const msg = props.data
   const [content, setContent] = useState<string>(() => getCachedDecryptedContent(msg.id))
+  const [decryptFailed, setDecryptFailed] = useState(false)
   const { ref, inView } = useInView({ triggerOnce: true })
   const { formatMessage } = useIntl()
   const isMe = msg.from === publicKey
@@ -32,10 +33,20 @@ export default function DM(props: DMProps) {
     const m = msgRef.current
     if (publisher && !getCachedDecryptedContent(m.id)) {
       const decrypted = await m.decrypt(publisher)
-      const result = decrypted || "<ERROR>"
-      setCachedDecryptedContent(m.id, result)
-      setContent(result)
-      props.chat.markRead(m.id)
+      if (decrypted) {
+        setCachedDecryptedContent(m.id, decrypted)
+        setContent(decrypted)
+        props.chat.markRead(m.id)
+      } else {
+        // Decryption failed — typically because this gift wrap is not
+        // addressed to the local user (e.g. an outbound self-copy from
+        // a NIP-17 dual-publish client) or has a malformed payload.
+        // Don't cache the failure (so a future code path or session
+        // can retry) and don't mark it read (so unread counts stay
+        // accurate). Surface it as a subtle indicator instead of the
+        // literal placeholder string "<ERROR>".
+        setDecryptFailed(true)
+      }
     }
   }, [publisher])
 
@@ -76,6 +87,10 @@ export default function DM(props: DMProps) {
         {sender()}
         {content ? (
           <Text id={msg.id} content={content} tags={[]} creator={otherPubkey} />
+        ) : decryptFailed ? (
+          <span className="italic text-gray-400">
+            <FormattedMessage defaultMessage="Unable to decrypt message" />
+          </span>
         ) : (
           <FormattedMessage defaultMessage="Loading..." />
         )}


### PR DESCRIPTION
## Summary

Failed NIP-17 decrypts render the literal string `<ERROR>` in the thread bubble and sidebar preview, get cached, and trigger `markRead`. Three consequences: (1) broken-looking UI, (2) the cached `<ERROR>` overrides any future successful decrypt with the correct key, (3) unread count drifts because failed wraps are marked read.

Decrypt failures are routine, not exceptional: NIP-17 senders commonly publish a self-copy (spec-compliant per NIP-59) that lands in the recipient's `#p` filter undecryptable; cross-identity sessions; stale or malformed payloads.

## Changes

In `Pages/Messages/DM.tsx`:

- Only call `setCachedDecryptedContent` and `props.chat.markRead` when decrypt succeeds
- On failure, set a local `decryptFailed` flag and render an italic "Unable to decrypt message" placeholder via `FormattedMessage` (localizable)
- Cache stays untouched on failure, so a later session with the right key can still decrypt the wrap

## Related

- [NIP-17 — Private Direct Messages](https://github.com/nostr-protocol/nips/blob/master/17.md)
- [NIP-59 — Gift Wrap](https://github.com/nostr-protocol/nips/blob/master/59.md)
- [NIP-44 — Encrypted Payloads](https://github.com/nostr-protocol/nips/blob/master/44.md)
